### PR TITLE
Drop the ExecStopPost exit helper; read exit code from systemd

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -137,6 +137,41 @@ func awaitQuiet(timeout, step time.Duration, maxPerStep int64, total func() int6
 
 // --- integration helpers ---
 
+// TestLoadExitFromUnitReadsRealExitCode is the load-bearing check for removing
+// the ExecStopPost exit helper: with no helper writing the state file on stop,
+// the reconcile path's only source of the terminal code is systemd's
+// ExecMainStatus. This confirms it is populated and read for a real exit.
+// Signal, tty, and mount-cleanup behaviour is exercised by the container-level
+// integration harness, where the unit wraps a real runc container rather than a
+// bare shell (a self-signalled transient unit does not faithfully model it).
+func TestLoadExitFromUnitReadsRealExitCode(t *testing.T) {
+	ctx := context.Background()
+	path := privateBusPath(t)
+	reg := newUnitRegistry(t, path)
+	conn := dialPrivate(t, ctx, path)
+	defer conn.Close()
+
+	t.Run("a non-zero exit is read from ExecMainStatus", func(t *testing.T) {
+		unit := reg.unit("exit-nonzero")
+		startTransient(t, ctx, conn, unit, []string{"/bin/sh", "-c", "exit 7"})
+
+		var st pState
+		if !eventually(10*time.Second, 20*time.Millisecond, func() bool {
+			s, err := loadExitFromUnit(ctx, conn, unit)
+			if err != nil {
+				return false
+			}
+			st = s
+			return st.Exited()
+		}) {
+			t.Fatalf("unit %s never reported an exit via systemd", unit)
+		}
+		if st.ExitCode != 7 {
+			t.Fatalf("expected exit code 7 from systemd, got %d", st.ExitCode)
+		}
+	})
+}
+
 // privateBusPath returns the address of a systemd private bus to test against,
 // or skips the test when one is not available. It skips in -short mode (these
 // tests talk to a real systemd and create transient units) and when no private

--- a/main.go
+++ b/main.go
@@ -11,7 +11,6 @@ import "C"
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -25,10 +24,8 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/containerd/containerd/defaults"
 	"github.com/containerd/containerd/errdefs"
@@ -38,7 +35,6 @@ import (
 	"github.com/containerd/containerd/runtime/v2/shim"
 	taskapi "github.com/containerd/containerd/runtime/v2/task"
 	"github.com/coreos/go-systemd/v22/activation"
-	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/cpuguy83/containerd-shim-systemd-v1/options"
 	"github.com/gogo/protobuf/proto"
 	"github.com/pelletier/go-toml"
@@ -268,95 +264,6 @@ func main() {
 				}
 			}
 			return createCmd(ctx, bundle, flags.Args(), tty, mountCfg != "")
-		},
-		"exit": func(ctx context.Context) error {
-			ctx = log.WithLogger(ctx, log.G(ctx).WithField("unit", os.Getenv("UNIT_NAME")))
-			ctx = WithShimLog(ctx, OpenShimLog(ctx, bundle))
-
-			conn, err := systemd.NewSystemdConnectionContext(ctx)
-			if err != nil {
-				return err
-			}
-
-			var st pState
-			statusData, err := os.ReadFile(os.Getenv("EXIT_STATE_PATH"))
-			if err != nil {
-				if !os.IsNotExist(err) {
-					log.G(ctx).WithError(err).Error("Error reading status")
-				}
-			} else {
-				if err := json.Unmarshal(statusData, &st); err != nil {
-					return fmt.Errorf("error unmarshaling status: %v", err)
-				}
-
-				if st.Exited() {
-					return nil
-				}
-			}
-
-			code, err := strconv.Atoi(os.Getenv("EXIT_STATUS"))
-			if err != nil {
-				code = 255
-				if os.Getenv("EXIT_STATUS") == "" {
-					log.G(ctx).WithError(err).Errorf("Error reading exit status, falling back to file: %s", flags.Arg(0))
-
-					// Fallback to exit status written by our `create` subcommand
-					// This is currently needed for type=forking where the exec'd process exits quickly.
-					exitData, err := os.ReadFile(flags.Arg(0))
-					if err == nil {
-						c, err := strconv.Atoi(string(exitData))
-						if err != nil {
-							log.G(ctx).WithError(err).Warn("Error parsing exit code from file")
-							code = 255
-						} else {
-							code = c
-						}
-					} else {
-						log.G(ctx).WithError(err).Warn("Error reading exit code from file")
-					}
-				}
-			}
-
-			if st.Pid == 0 {
-				pidData, err := os.ReadFile(os.Getenv("PIDFILE"))
-				if err != nil {
-					return fmt.Errorf("error reading pidfile: %v", err)
-				}
-				pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
-				if err != nil {
-					return fmt.Errorf("error parsing pid: %v", err)
-				}
-				st.Pid = uint32(pid)
-			}
-
-			st.Status = os.Getenv("EXIT_CODE")
-			st.ExitedAt = time.Now()
-			st.ExitCode = uint32(code)
-
-			if st.ExitCode == 255 {
-				log.G(ctx).Debug("Falling back to reading exit status from systemd api")
-				var st2 pState
-				if err := getUnitState(ctx, conn, os.Getenv("UNIT_NAME"), &st); err != nil {
-					log.G(ctx).WithError(err).Error("Error reading unit state")
-				}
-				if st2.ExitCode > 0 {
-					st.ExitCode = st2.ExitCode
-				}
-			}
-
-			data, err := json.Marshal(st)
-			if err != nil {
-				return err
-			}
-
-			if err := os.WriteFile(os.Getenv("EXIT_STATE_PATH"), data, 0600); err != nil {
-				return fmt.Errorf("error writing status: %v", err)
-			}
-
-			// The shim observes this exit over D-Bus (the unit only reaches
-			// inactive/failed after this ExecStopPost completes, so the state
-			// file above is already in place when it reconciles).
-			return nil
 		},
 	}
 

--- a/process.go
+++ b/process.go
@@ -125,6 +125,12 @@ type Process interface {
 	// identifier the event reactor matches incoming signals against.
 	PathName() string
 	LoadState(context.Context) error
+	// LoadExitState refreshes the process state from systemd's record of the
+	// unit (ExecMainStatus/SubState). The exit reactor uses it to obtain the
+	// terminal exit code on a real exit -- the persisted state file only carries
+	// a running state -- so the GetAll it performs stays off the hot LoadState
+	// path.
+	LoadExitState(context.Context) error
 	SetState(context.Context, pState) pState
 	ProcessState() pState
 	LogWriter() io.Writer

--- a/start.go
+++ b/start.go
@@ -117,7 +117,6 @@ func (p *initProcess) startOptions(rcmd []string) ([]*unit.UnitOption, error) {
 		unit.NewUnitOption(svc, "RemainAfterExit", "no"),
 		unit.NewUnitOption(svc, "PIDFile", p.pidFile()),
 		unit.NewUnitOption(svc, "Delegate", "yes"),
-		unit.NewUnitOption(svc, "ExecStopPost", "-"+p.exe+" --bundle="+p.Bundle+" exit "+os.Getenv("UNIT_NAME")),
 		// Set this as env vars here because we only want these fifos to be used for the container stdio, not the other commands we run.
 		// Otherwise we can run into interesting cases like the client has closeed the fifo and our Pre/Post commands hang
 		// We already had to open these fifos in process to prevent such hangs with `ExecStart`, now instead it'll open them just before
@@ -173,7 +172,6 @@ func (p *execProcess) startOptions() ([]*unit.UnitOption, error) {
 		unit.NewUnitOption(svc, "GuessMainPID", "yes"),
 		unit.NewUnitOption(svc, "Delegate", "yes"),
 		unit.NewUnitOption(svc, "RemainAfterExit", "no"),
-		unit.NewUnitOption(svc, "ExecStopPost", "-"+p.exe+" --debug="+strconv.FormatBool(p.runc.Debug)+" --id="+p.id+" --bundle="+p.parent.Bundle+" exit"),
 
 		// Set this as env vars here because we only want these fifos to be used for the container stdio, not the other commands we run.
 		// Otherwise we can run into interesting cases like the client has closeed the fifo and our Pre/Post commands hang

--- a/state.go
+++ b/state.go
@@ -174,6 +174,42 @@ func (p *execProcess) LoadState(ctx context.Context) error {
 	return nil
 }
 
+// loadExitFromUnit reads a unit's terminal exit from systemd (ExecMainStatus and
+// SubState via GetAll). It is the reconcile path's exit-code source: no
+// ExecStopPost helper writes the state file on stop anymore, and create persists
+// only a running state, so on a real exit the code must come from systemd's
+// still-loaded unit. getUnitState leaves ExitedAt unset, so stamp it for a clean
+// exit whose code is 0 (its exited status still comes through SubState).
+func loadExitFromUnit(ctx context.Context, conn *dbus.Conn, name string) (pState, error) {
+	var st pState
+	st.Reset()
+	if err := getUnitState(ctx, conn, name, &st); err != nil {
+		return pState{}, err
+	}
+	if st.Exited() && !st.ExitedAt.After(timeZero) {
+		st.ExitedAt = time.Now()
+	}
+	return st, nil
+}
+
+func (p *initProcess) LoadExitState(ctx context.Context) error {
+	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
+	if err != nil {
+		return err
+	}
+	p.SetState(ctx, st)
+	return nil
+}
+
+func (p *execProcess) LoadExitState(ctx context.Context) error {
+	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
+	if err != nil {
+		return err
+	}
+	p.SetState(ctx, st)
+	return nil
+}
+
 func (p *execProcess) exitStatePath() string {
 	return filepath.Join(p.stateDir(), "exit_status.json")
 }

--- a/unitevents.go
+++ b/unitevents.go
@@ -298,6 +298,19 @@ func reconcileUnit(ctx context.Context, units processLookup, pathBase string) er
 	if err := p.LoadState(ctx); err != nil {
 		return err
 	}
+
+	// The exit signal says the unit stopped, but create persists only a running
+	// state file: the terminal exit code lives in systemd's ExecMainStatus, which
+	// the Unit-interface signal does not carry. When the persisted state is not
+	// yet terminal for a started process, read the real exit from the
+	// still-loaded unit. A Pid of 0 means the unit never started (the leading
+	// pre-start inactive/dead event), so there is nothing to read and systemd's
+	// "dead" substate must not be mistaken for an exit.
+	if !p.ProcessState().Exited() && p.Pid() > 0 {
+		if err := p.LoadExitState(ctx); err != nil {
+			return err
+		}
+	}
 	log.G(ctx).WithField("state", p.ProcessState()).Debug("Reconciled unit after exit event")
 	return nil
 }

--- a/unitevents_test.go
+++ b/unitevents_test.go
@@ -217,6 +217,99 @@ func TestReactToUnitEvents(t *testing.T) {
 		}
 	})
 
+	t.Run("a started process whose persisted state is not terminal reads the exit code from systemd", func(t *testing.T) {
+		p := &fakeProcess{
+			name: unit,
+			loadStateFn: func(f *fakeProcess) error {
+				f.setState(pState{Pid: 42, Status: "running"}) // create's running-state file
+				return nil
+			},
+			loadExitStateFn: func(f *fakeProcess) error {
+				f.setState(pState{Pid: 42, ExitCode: 7, ExitedAt: time.Now()})
+				return nil
+			},
+		}
+		units := &fakeLookup{m: map[string]Process{unit: p}}
+
+		updates := make(chan unitUpdate, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() { reactToUnitEvents(ctx, units, seqFromChan(ctx, updates)); close(done) }()
+
+		updates <- exitUpdate(unit)
+
+		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.ProcessState().Exited() }) {
+			t.Fatal("reactor never read the terminal exit from systemd")
+		}
+		if got := p.ProcessState().ExitCode; got != 7 {
+			t.Fatalf("expected exit code 7 from systemd, got %d", got)
+		}
+		if got := p.LoadExitStateCalls(); got != 1 {
+			t.Fatalf("expected exactly one systemd exit read, got %d", got)
+		}
+		cancel()
+		<-done
+	})
+
+	t.Run("an unstarted process does not read the exit code from systemd", func(t *testing.T) {
+		p := &fakeProcess{name: unit, loadStateFn: func(f *fakeProcess) error {
+			return nil // models LoadState no-op for a not-yet-started process (pid==0)
+		}}
+		units := &fakeLookup{m: map[string]Process{unit: p}}
+
+		updates := make(chan unitUpdate, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() { reactToUnitEvents(ctx, units, seqFromChan(ctx, updates)); close(done) }()
+
+		updates <- exitUpdate(unit) // pre-start inactive/dead
+
+		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.LoadStateCalls() >= 1 }) {
+			t.Fatal("reactor never reconciled the pre-start event")
+		}
+		if got := p.LoadExitStateCalls(); got != 0 {
+			t.Fatalf("expected no systemd exit read for an unstarted unit, got %d", got)
+		}
+		if p.ProcessState().Exited() {
+			t.Fatal("pre-start event spuriously marked the process exited")
+		}
+		cancel()
+		<-done
+	})
+
+	t.Run("a persisted terminal exit is not re-read from systemd", func(t *testing.T) {
+		p := &fakeProcess{name: unit, loadStateFn: func(f *fakeProcess) error {
+			f.setState(pState{Pid: 9, ExitCode: 2, ExitedAt: time.Now()}) // create's fast-exit file
+			return nil
+		}}
+		units := &fakeLookup{m: map[string]Process{unit: p}}
+
+		updates := make(chan unitUpdate, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() { reactToUnitEvents(ctx, units, seqFromChan(ctx, updates)); close(done) }()
+
+		updates <- exitUpdate(unit)
+
+		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.LoadStateCalls() >= 1 }) {
+			t.Fatal("reactor never reconciled the unit")
+		}
+		if got := p.LoadExitStateCalls(); got != 0 {
+			t.Fatalf("expected no systemd exit read when the file is already terminal, got %d", got)
+		}
+		if got := p.ProcessState().ExitCode; got != 2 {
+			t.Fatalf("expected the persisted exit code 2 to stand, got %d", got)
+		}
+		cancel()
+		<-done
+	})
+
 	t.Run("a non-exit event does not trigger a state read", func(t *testing.T) {
 		p := &fakeProcess{name: unit}
 		units := &fakeLookup{m: map[string]Process{unit: p}}
@@ -651,11 +744,13 @@ func (l *fakeLookup) remove(name string) {
 }
 
 type fakeProcess struct {
-	name        string
-	mu          sync.Mutex
-	state       pState
-	loadCalls   int32
-	loadStateFn func(*fakeProcess) error
+	name            string
+	mu              sync.Mutex
+	state           pState
+	loadCalls       int32
+	loadExitCalls   int32
+	loadStateFn     func(*fakeProcess) error
+	loadExitStateFn func(*fakeProcess) error
 }
 
 // LoadState mirrors the real implementations, which do NOT hold the process lock
@@ -672,6 +767,20 @@ func (f *fakeProcess) LoadState(context.Context) error {
 
 func (f *fakeProcess) LoadStateCalls() int {
 	return int(atomic.LoadInt32(&f.loadCalls))
+}
+
+// LoadExitState mirrors the real reconcile-path systemd read. Like LoadState it
+// does not hold the process lock while running loadExitStateFn.
+func (f *fakeProcess) LoadExitState(context.Context) error {
+	atomic.AddInt32(&f.loadExitCalls, 1)
+	if f.loadExitStateFn != nil {
+		return f.loadExitStateFn(f)
+	}
+	return nil
+}
+
+func (f *fakeProcess) LoadExitStateCalls() int {
+	return int(atomic.LoadInt32(&f.loadExitCalls))
 }
 
 func (f *fakeProcess) setState(st pState) {


### PR DESCRIPTION
## Why

The D-Bus reactor is now the shim's exit monitor, so the per-unit `ExecStopPost` `exit` re-exec no longer needs to persist exit state when a unit stops. This removes it and the `exit` subcommand.

Its one remaining job was recording the container's real exit code. Nothing else does: `create` (the ExecStart re-exec) wraps `runc create` / `runc exec --detach` and returns once the container is merely *up*, so it normally persists only a running state; and the Unit-interface D-Bus signal the reactor observes reports *that* the unit stopped but not its exit code (`ExecMainStatus` lives on the Service interface, which the signal doesn't carry).

## What changed

- Remove the `exit` `ExecStopPost` line from init and exec unit options, and delete the `exit` subcommand.
- On reconcile, when the persisted state is not yet terminal and the unit has a pid, read the terminal exit from systemd (`ExecMainStatus`/`SubState`). The read stays off the hot `LoadState` path, and the pid guard prevents the leading pre-start `inactive/dead` event from being mistaken for an exit.

The `unmount` and tty-stop `ExecStopPost` lines are unaffected — they never went through the `exit` helper (and `Delete` already backstops both).

## Trade-off

`ExecMainStatus` moves from a fallback to the reactor's primary exit-code source, so it must be reliably populated for our forking and notify units at inactive/failed.

## Testing

- Unit (`unitevents_test.go`): a started-but-not-terminal unit reads its code from systemd; an unstarted unit does not; a persisted terminal exit is not re-read.
- Live systemd (`integration_test.go`): a non-zero exit is read from `ExecMainStatus`.
- `go build`, `go vet`, `go test ./...` (incl. live-systemd), `gofmt` all pass.

Signal / tty / mount-cleanup behaviour is left to the container-level integration harness (real runc container); a bare self-signalled transient unit is not representative — systemd reports `Result=success` / `ExecMainStatus=0` for it.