### PR TITLE
Fix tty handler error reporting

### DIFF
--- a/delete.go
+++ b/delete.go
@@ -164,6 +164,8 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 	p.cond.Broadcast()
 	p.mu.Unlock()
 
+	p.closeTTYControl()
+
 	return ps, nil
 }
 
@@ -217,6 +219,8 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 	p.deleted = true
 	p.cond.Broadcast()
 	p.mu.Unlock()
+
+	p.closeTTYControl()
 
 	p.parent.execs.Delete(p.execID)
 	if err := os.Remove(p.unitPath()); err != nil {

--- a/process.go
+++ b/process.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -208,7 +207,8 @@ type process struct {
 
 	systemd *systemd.Conn
 	runc    *runc.Runc
-	ttyConn net.Conn
+
+	ttyControl *ttyControlClient
 
 	mu           sync.Mutex
 	cond         *sync.Cond

--- a/pty.c
+++ b/pty.c
@@ -39,100 +39,126 @@ void *copy(void *args)
     return 0;
 }
 
+// write_all writes the whole buffer, looping over short writes.
+// Returns 0 on success and -1 if any write fails.
+int write_all(int fd, const char *buf, size_t len)
+{
+    size_t off = 0;
+    while (off < len)
+    {
+        ssize_t n = write(fd, buf + off, len - off);
+        if (n < 0)
+            return -1;
+        off += (size_t)n;
+    }
+    return 0;
+}
+
+// The tty client protocol is a newline-framed status line per request:
+//   "0\n"            on success
+//   "1 <message>\n"  on error
+// reply_ok/reply_err write one such line. They return 0 on success and -1 on
+// write failure.
+int reply_ok(int fd)
+{
+    return write_all(fd, "0\n", 2);
+}
+
+int reply_err(int fd, const char *msg)
+{
+    char buf[256];
+    int n = snprintf(buf, sizeof(buf), "1 %s\n", msg);
+    if (n < 0)
+        return -1;
+    if (n >= (int)sizeof(buf))
+        n = sizeof(buf) - 1;
+    return write_all(fd, buf, (size_t)n);
+}
+
+// handle_tty_request services a single request line (newline already stripped),
+// writing exactly one status line back to the client. It returns 0 when the
+// connection should stay open -- including recoverable errors that were reported
+// to the client -- and -1 when a socket write failed and the caller should close.
+int handle_tty_request(int fd, const char *line)
+{
+    int op, w, h;
+    if (sscanf(line, "%d %d %d", &op, &w, &h) != 3)
+    {
+        lerror("parse");
+        return reply_err(fd, "invalid resize request");
+    }
+
+    if (op != op_resize)
+        return reply_err(fd, "unknown operation");
+
+    struct winsize ws;
+    memset(&ws, 0, sizeof(ws));
+    ws.ws_col = w;
+    ws.ws_row = h;
+
+    if (ioctl(tty_fd, TIOCSWINSZ, &ws) < 0)
+    {
+        lerror("ioctl TIOCSWINSZ");
+        return reply_err(fd, "error setting window size");
+    }
+
+    return reply_ok(fd);
+}
+
 void handle_tty_op_conn(int fd)
 {
-    int nr, nw;
     char buf[256];
+    // len is how many bytes of a not-yet-complete request are buffered. The
+    // socket is a byte stream, so a single read() may return a partial request
+    // or several requests at once; we buffer until each '\n' before parsing so
+    // fragmentation cannot desynchronize requests from responses.
+    size_t len = 0;
 
     while (1)
     {
-        nr = read(fd, buf, sizeof(buf));
+        // Leave room to NUL-terminate for sscanf.
+        ssize_t nr = read(fd, buf + len, sizeof(buf) - 1 - len);
         if (nr < 0)
         {
             lerror("read");
             close(fd);
             return;
         }
-
-        if (nr < 1)
+        if (nr == 0)
         {
-            char *msg = "invalid operation";
-            nw = write(fd, msg, sizeof(msg));
-            if (nw < 0)
-            {
-                lerror("write");
-                close(fd);
-                return;
-            }
-        }
-
-        int op, w, h;
-        int err;
-
-        char op_buf[nr];
-
-        // TODO: this is pretty sloppy
-        // We aren't checking that the data sent is valid and includes everything we expect.
-        memcpy(op_buf, buf, nr);
-        err = sscanf(op_buf, "%d %d %d", &op, &w, &h);
-        if (err < 0)
-        {
-            char *msg = "parse error";
-            nw = write(fd, msg, sizeof(msg));
-            if (nw < 0)
-            {
-                lerror("write");
-                close(fd);
-                return;
-            }
-            lerror("parse");
+            // The client closed the connection.
             close(fd);
             return;
         }
+        len += (size_t)nr;
 
-        if (op != op_resize)
+        // Service every complete, newline-terminated request in the buffer.
+        char *start = buf;
+        char *nl;
+        while ((nl = memchr(start, '\n', (buf + len) - start)) != NULL)
         {
-            char *msg = "invalid operation";
-            nw = write(fd, msg, sizeof(msg));
-            if (nw < 0)
+            *nl = '\0';
+            if (handle_tty_request(fd, start) < 0)
             {
                 lerror("write");
                 close(fd);
                 return;
             }
+            start = nl + 1;
         }
 
-        struct winsize *ws = (struct winsize *)malloc(sizeof(struct winsize));
-        ws->ws_col = w;
-        ws->ws_row = h;
+        // Keep any trailing partial request for the next read.
+        len -= (size_t)(start - buf);
+        memmove(buf, start, len);
 
-        err = ioctl(tty_fd, TIOCSWINSZ, ws);
-        free(ws);
-        if (err < 0)
+        // A request that fills the buffer without a newline is malformed.
+        if (len == sizeof(buf) - 1)
         {
-            lerror("ioctl TIOCSWINSZ");
-            char *msg = "error setting win size";
-            nw = write(fd, msg, sizeof(msg));
-            if (nw < 0)
-            {
-                lerror("write");
-                close(fd);
-                return;
-            }
-        }
-
-        // Send ack
-        nw = write(fd, "0", 1);
-        if (nw < 1)
-        {
-            lerror("write");
+            reply_err(fd, "request too long");
             close(fd);
             return;
         }
     }
-
-    close(fd);
-    return;
 }
 
 void *handle_tty_ops(void *args)

--- a/pty.go
+++ b/pty.go
@@ -1,14 +1,18 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"os"
 	"path"
 	"path/filepath"
 	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
@@ -20,7 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
-	"golang.org/x/sys/unix"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -29,6 +32,182 @@ const (
 	ttyHandshakeEnv = "_TTY_HANDSHAKE"
 )
 
+// The tty handler protocol is a small newline-framed, text request/response
+// exchanged over a persistent unix socket. A request is "<op> <width> <height>"
+// and a response is a single status line: "0" on success or "1 <message>" on
+// error. These constants are mirrored by op_resize/reply_* in pty.c.
+const (
+	ttyOpResize  = 1
+	ttyStatusOK  = "0"
+	ttyStatusErr = "1"
+
+	// maxTTYResponseLen bounds how many bytes we buffer for a single response
+	// line so a misbehaving handler cannot make us read without limit. It
+	// comfortably exceeds the longest reply pty.c can produce.
+	maxTTYResponseLen = 256
+
+	// ttyRequestBufSize sizes the reusable request buffer. A resize request is
+	// "<op> <width> <height>\n"; width and height arrive as uint32 (at most 10
+	// digits each), so the longest possible request, "1 4294967295 4294967295\n",
+	// is 24 bytes. Rounded up for headroom.
+	ttyRequestBufSize = 32
+
+	// ttyResponseTimeout bounds a single resize exchange. The read runs while the
+	// process lock is held, so without a deadline a stuck handler -- or an old,
+	// pre-framing handler that writes a bare "0" and never sends the newline this
+	// client now waits for -- would hang the whole lifecycle. The timeout is
+	// generous: a healthy handler replies in microseconds.
+	ttyResponseTimeout = 2 * time.Second
+)
+
+// ttyControlClient sends control operations to a container's tty handler over
+// its unix control socket. The handler speaks the small newline-framed
+// request/response protocol described above; this client hides that behind
+// Resize and Close, dialing lazily and reusing the connection across resizes.
+// Its own mutex serializes exchanges, so tty I/O never blocks the process
+// lifecycle lock.
+type ttyControlClient struct {
+	sockPath string
+
+	mu     sync.Mutex
+	conn   net.Conn
+	reader *bufio.Reader
+	limit  *io.LimitedReader
+	// buf is a reusable scratch buffer for encoding each request, so a resize
+	// does not allocate.
+	buf [ttyRequestBufSize]byte
+}
+
+func newTTYControlClient(sockPath string) *ttyControlClient {
+	return &ttyControlClient{sockPath: sockPath}
+}
+
+// Resize sets the tty window size. It dials the handler on first use and reuses
+// the connection thereafter; if the exchange fails it drops the connection so
+// the next resize redials.
+func (c *ttyControlClient) Resize(ctx context.Context, width, height int) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.conn == nil {
+		if err := c.dial(); err != nil {
+			return err
+		}
+	}
+
+	line, err := c.exchange(ctx, appendTTYResizeRequest(c.buf[:0], width, height))
+	if err != nil {
+		// The handler is a transient local unit: a failed exchange means it is
+		// gone, not that a retry would help, so just drop the connection and let
+		// the next resize redial.
+		c.reset()
+		return err
+	}
+	return parseTTYResponse(line)
+}
+
+// Close closes the control connection. It is safe to call more than once and
+// concurrently with Resize. The caller must not hold c.mu.
+func (c *ttyControlClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reset()
+}
+
+// dial establishes the control connection and its bounded reader. The caller
+// holds c.mu.
+func (c *ttyControlClient) dial() error {
+	conn, err := net.Dial("unix", c.sockPath)
+	if err != nil {
+		return fmt.Errorf("could not dial tty sock: %w", err)
+	}
+	c.conn = conn
+	c.limit = &io.LimitedReader{R: conn}
+	c.reader = bufio.NewReader(c.limit)
+	return nil
+}
+
+// reset closes and clears the control connection, returning the close error.
+// The caller holds c.mu.
+func (c *ttyControlClient) reset() error {
+	if c.conn == nil {
+		return nil
+	}
+	err := c.conn.Close()
+	c.conn, c.reader, c.limit = nil, nil, nil
+	return err
+}
+
+// exchange writes req and reads one response line, bounded by ttyResponseTimeout
+// (or an earlier context deadline). The caller holds c.mu.
+func (c *ttyControlClient) exchange(ctx context.Context, req []byte) (string, error) {
+	deadline := time.Now().Add(ttyResponseTimeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	if err := c.conn.SetDeadline(deadline); err != nil {
+		return "", fmt.Errorf("error setting tty handler deadline: %w", err)
+	}
+
+	if _, err := c.conn.Write(req); err != nil {
+		return "", fmt.Errorf("error writing winsize to the tty handler: %w", err)
+	}
+
+	line, err := c.readMsg()
+	if err != nil {
+		return "", fmt.Errorf("error reading response from tty handler: %w", err)
+	}
+	return line, nil
+}
+
+// readMsg reads one status line from the handler, bounding the read at
+// maxTTYResponseLen bytes via the reusable limit. A well-behaved handler ends
+// the line with a newline. An older, pre-framing handler writes an unframed
+// reply (e.g. a bare "0") then waits for the next request, so no newline
+// arrives; the read then ends by deadline or EOF with the message buffered, and
+// we return it rather than hanging or reporting a failure. The caller holds c.mu.
+func (c *ttyControlClient) readMsg() (string, error) {
+	c.limit.N = maxTTYResponseLen
+	line, err := c.reader.ReadString('\n')
+	if err != nil {
+		if c.limit.N <= 0 {
+			return "", fmt.Errorf("tty handler response exceeded %d bytes without a newline", maxTTYResponseLen)
+		}
+		if len(line) == 0 {
+			return "", err
+		}
+		// Unframed reply: the message is buffered but no newline arrived.
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+// appendTTYResizeRequest appends a newline-terminated resize request to buf and
+// returns the extended buffer, so a caller can reuse a single buffer across
+// resizes instead of allocating one per call.
+func appendTTYResizeRequest(buf []byte, width, height int) []byte {
+	buf = strconv.AppendInt(buf, ttyOpResize, 10)
+	buf = append(buf, ' ')
+	buf = strconv.AppendInt(buf, int64(width), 10)
+	buf = append(buf, ' ')
+	buf = strconv.AppendInt(buf, int64(height), 10)
+	return append(buf, '\n')
+}
+
+// parseTTYResponse interprets a single status line from the tty handler.
+func parseTTYResponse(line string) error {
+	line = strings.TrimRight(line, "\r\n")
+	switch {
+	case line == ttyStatusOK:
+		return nil
+	case line == ttyStatusErr:
+		return fmt.Errorf("tty handler returned an unspecified error")
+	case strings.HasPrefix(line, ttyStatusErr+" "):
+		return fmt.Errorf("tty handler returned an error: %s", strings.TrimPrefix(line, ttyStatusErr+" "))
+	default:
+		return fmt.Errorf("tty handler returned an unexpected response: %q", line)
+	}
+}
+
 func (p *process) ResizePTY(ctx context.Context, width, height int, sockPath string) error {
 	if !p.Terminal {
 		// This mimics what the runc shim does, and what the containerd integration tests expect
@@ -36,46 +215,26 @@ func (p *process) ResizePTY(ctx context.Context, width, height int, sockPath str
 	}
 
 	p.mu.Lock()
-	defer p.mu.Unlock()
+	if p.ttyControl == nil {
+		p.ttyControl = newTTYControlClient(sockPath)
+	}
+	c := p.ttyControl
+	p.mu.Unlock()
 
-	conn := p.ttyConn
+	return c.Resize(ctx, width, height)
+}
 
-	var noRetry bool
-	if conn == nil {
-		noRetry = true
-		var err error
-		conn, err = net.Dial("unix", sockPath)
-		if err != nil {
-			return fmt.Errorf("could not dial tty sock: %w", err)
-		}
-		p.ttyConn = conn
+// closeTTYControl detaches and closes the process's tty control client, if any.
+// It holds p.mu only to detach the pointer, never across the close, so a slow or
+// stuck resize cannot wedge the lifecycle lock.
+func (p *process) closeTTYControl() {
+	p.mu.Lock()
+	c := p.ttyControl
+	p.ttyControl = nil
+	p.mu.Unlock()
+	if c != nil {
+		c.Close()
 	}
-
-	_, err := conn.Write([]byte("1 " + strconv.Itoa(width) + " " + strconv.Itoa(height)))
-	if err != nil {
-		if !noRetry {
-			p.ttyConn.Close()
-			p.ttyConn = nil
-			return p.ResizePTY(ctx, width, height, sockPath)
-		}
-		return fmt.Errorf("error writing winsize to the tty handler: %w", err)
-	}
-
-	resp := make([]byte, 128)
-	n, err := conn.Read(resp)
-	if err != nil {
-		return fmt.Errorf("error reading ack from tty handler: %w", err)
-	}
-	if n > 1 {
-		return fmt.Errorf("tty handler returned an error: %s", string(resp[:n]))
-	}
-	if n == 0 {
-		return fmt.Errorf("tty handler returned no data")
-	}
-	if resp[0] != '0' {
-		return fmt.Errorf("tty handler returned unknown response code %s", string(resp[:n]))
-	}
-	return nil
 }
 
 // ResizePty of a process
@@ -91,9 +250,9 @@ func (s *Service) ResizePty(ctx context.Context, r *taskapi.ResizePtyRequest) (_
 		"apiAction": "resizePty",
 	}))
 
-	log.G(ctx).Info("systemd.ResizePTY start")
+	log.G(ctx).Debug("systemd.ResizePTY start")
 	defer func() {
-		log.G(ctx).WithError(retErr).Info("systemd.ResizePTY end")
+		log.G(ctx).WithError(retErr).Debug("systemd.ResizePTY end")
 		if retErr != nil {
 			retErr = errgrpc.ToGRPC(retErr)
 		}
@@ -141,47 +300,6 @@ func (s *Service) CloseIO(ctx context.Context, r *taskapi.CloseIORequest) (_ *em
 	return &emptypb.Empty{}, nil
 }
 
-// This is pretty standard stuff but I copied this from github.com/containerd/go-runc, with some minor changes.
-// This receives the pty master fd from runc.
-func recvFd(socket *net.UnixConn) (int, error) {
-	const MaxNameLen = 4096
-	var oobSpace = unix.CmsgSpace(4)
-
-	name := make([]byte, MaxNameLen)
-	oob := make([]byte, oobSpace)
-
-	n, oobn, _, _, err := socket.ReadMsgUnix(name, oob)
-	if err != nil {
-		return -1, err
-	}
-
-	if n >= MaxNameLen || oobn != oobSpace {
-		return -1, fmt.Errorf("recvfd: incorrect number of bytes read (n=%d oobn=%d)", n, oobn)
-	}
-
-	// Truncate.
-	name = name[:n]
-	oob = oob[:oobn]
-
-	scms, err := unix.ParseSocketControlMessage(oob)
-	if err != nil {
-		return -1, err
-	}
-	if len(scms) != 1 {
-		return -1, fmt.Errorf("recvfd: number of SCMs is not 1: %d", len(scms))
-	}
-	scm := scms[0]
-
-	fds, err := unix.ParseUnixRights(&scm)
-	if err != nil {
-		return -1, err
-	}
-	if len(fds) != 1 {
-		return -1, fmt.Errorf("recvfd: number of fds is not 1: %d", len(fds))
-	}
-	return fds[0], nil
-}
-
 func (p *initProcess) ttySockPath() (string, error) {
 	sockInfoPath := filepath.Join(p.root, "tty.sock")
 	b, err := os.ReadFile(sockInfoPath)
@@ -193,12 +311,12 @@ func (p *initProcess) ttySockPath() (string, error) {
 		return "", err
 	}
 
-	tmp, err := ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "pty")
+	tmp, err := os.MkdirTemp(os.Getenv("XDG_RUNTIME_DIR"), "pty")
 	if err != nil {
 		return "", err
 	}
 	s := filepath.Join(tmp, "s")
-	if err := ioutil.WriteFile(sockInfoPath, []byte(s), 0600); err != nil {
+	if err := os.WriteFile(sockInfoPath, []byte(s), 0600); err != nil {
 		os.RemoveAll(tmp)
 		return "", err
 	}
@@ -217,12 +335,12 @@ func (p *execProcess) ttySockPath() (string, error) {
 		return "", err
 	}
 
-	tmp, err := ioutil.TempDir(os.Getenv("XDG_RUNTIME_DIR"), "pty")
+	tmp, err := os.MkdirTemp(os.Getenv("XDG_RUNTIME_DIR"), "pty")
 	if err != nil {
 		return "", err
 	}
 	s := filepath.Join(tmp, "s")
-	if err := ioutil.WriteFile(sockInfoPath, []byte(s), 0600); err != nil {
+	if err := os.WriteFile(sockInfoPath, []byte(s), 0600); err != nil {
 		os.RemoveAll(tmp)
 		return "", err
 	}
@@ -246,7 +364,7 @@ func (p *process) makePty(ctx context.Context, sockPath string) (_, _ string, re
 	logPath := filepath.Join(p.root, p.id+"-tty.log")
 	defer func() {
 		if retErr != nil {
-			logData, err := ioutil.ReadFile(logPath)
+			logData, err := os.ReadFile(logPath)
 			if err != nil {
 				log.G(ctx).WithError(err).Info("Could not read tty error log")
 			} else {

--- a/pty_test.go
+++ b/pty_test.go
@@ -1,10 +1,247 @@
 package main
 
 import (
+	"bufio"
+	"context"
+	"io"
+	"net"
+	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/coreos/go-systemd/v22/dbus"
 )
+
+func TestTTYControlClientReadMsg(t *testing.T) {
+	t.Run("a newline-terminated line is returned without the newline", func(t *testing.T) {
+		got, err := ttyClientReading("1 80 24\n").readMsg()
+		if err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+		if got != "1 80 24" {
+			t.Fatalf("got %q, want %q", got, "1 80 24")
+		}
+	})
+
+	t.Run("only the first line is consumed from a stream of many", func(t *testing.T) {
+		got, err := ttyClientReading("0\n0\n").readMsg()
+		if err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+		if got != "0" {
+			t.Fatalf("got %q, want %q", got, "0")
+		}
+	})
+
+	t.Run("an unframed reply ending without a newline is accepted", func(t *testing.T) {
+		// An older, pre-framing handler writes a bare "0" and no newline; the
+		// read ends at EOF (or, over a real socket, the deadline) with the reply
+		// buffered. It must be accepted rather than reported as a failure.
+		got, err := ttyClientReading("0").readMsg()
+		if err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+		if got != "0" {
+			t.Fatalf("got %q, want %q", got, "0")
+		}
+	})
+
+	t.Run("a closed connection with no reply is an error", func(t *testing.T) {
+		if _, err := ttyClientReading("").readMsg(); err == nil {
+			t.Fatal("got nil error, want one")
+		}
+	})
+
+	t.Run("a line longer than the cap without a newline is rejected", func(t *testing.T) {
+		_, err := ttyClientReading(strings.Repeat("x", maxTTYResponseLen+10)).readMsg()
+		if err == nil {
+			t.Fatal("got nil error, want one")
+		}
+		if !strings.Contains(err.Error(), "without a newline") {
+			t.Fatalf("error %q does not report the missing newline", err)
+		}
+	})
+}
+
+func TestParseTTYResponse(t *testing.T) {
+	t.Run("a bare ok status is success", func(t *testing.T) {
+		if err := parseTTYResponse("0\n"); err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+	})
+
+	t.Run("an ok status with no trailing newline is success", func(t *testing.T) {
+		if err := parseTTYResponse("0"); err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+	})
+
+	t.Run("an error status carries the handler message", func(t *testing.T) {
+		err := parseTTYResponse("1 error setting window size\n")
+		if err == nil {
+			t.Fatal("got nil error, want one")
+		}
+		if !strings.Contains(err.Error(), "error setting window size") {
+			t.Fatalf("error %q does not contain the handler message", err)
+		}
+	})
+
+	t.Run("a bare error status reports an unspecified error", func(t *testing.T) {
+		err := parseTTYResponse("1\n")
+		if err == nil {
+			t.Fatal("got nil error, want one")
+		}
+		if !strings.Contains(err.Error(), "unspecified") {
+			t.Fatalf("error %q does not mention it is unspecified", err)
+		}
+	})
+
+	t.Run("an unrecognized status is surfaced as unexpected", func(t *testing.T) {
+		err := parseTTYResponse("garbage\n")
+		if err == nil {
+			t.Fatal("got nil error, want one")
+		}
+		if !strings.Contains(err.Error(), "unexpected") {
+			t.Fatalf("error %q is not reported as unexpected", err)
+		}
+	})
+
+	t.Run("carriage returns and newlines are trimmed before matching", func(t *testing.T) {
+		if err := parseTTYResponse("0\r\n"); err != nil {
+			t.Fatalf("got error %v, want nil", err)
+		}
+	})
+}
+
+func TestAppendTTYResizeRequest(t *testing.T) {
+	t.Run("a resize request is the op, width and height terminated by a newline", func(t *testing.T) {
+		got := string(appendTTYResizeRequest(nil, 80, 24))
+		want := "1 80 24\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("reusing the buffer overwrites the previous request", func(t *testing.T) {
+		buf := appendTTYResizeRequest(nil, 80, 24)
+		got := string(appendTTYResizeRequest(buf[:0], 100, 40))
+		want := "1 100 40\n"
+		if got != want {
+			t.Fatalf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("encoding into the reusable buffer does not allocate", func(t *testing.T) {
+		var buf [ttyRequestBufSize]byte
+		var got []byte
+		// Largest possible request: op plus two max-uint32 dimensions.
+		allocs := testing.AllocsPerRun(1000, func() {
+			got = appendTTYResizeRequest(buf[:0], 4294967295, 4294967295)
+		})
+		if len(got) > len(buf) {
+			t.Fatalf("encoded %d bytes into a %d-byte buffer", len(got), len(buf))
+		}
+		if allocs != 0 {
+			t.Fatalf("appendTTYResizeRequest allocated %v times per call, want 0", allocs)
+		}
+	})
+}
+
+func TestResizePTY(t *testing.T) {
+	t.Run("a resize sends a framed request and succeeds on the handler ack", func(t *testing.T) {
+		h := startFakeTTYHandler(t, serveAcks)
+
+		p := newTTYProcess(t)
+		if err := runResize(t, p, h.sock, 80, 24); err != nil {
+			t.Fatalf("resize: %v", err)
+		}
+		if got := h.lastRequest(); got != "1 80 24" {
+			t.Fatalf("handler received request %q, want %q", got, "1 80 24")
+		}
+	})
+
+	t.Run("consecutive resizes reuse a single connection", func(t *testing.T) {
+		h := startFakeTTYHandler(t, serveAcks)
+
+		p := newTTYProcess(t)
+		if err := runResize(t, p, h.sock, 80, 24); err != nil {
+			t.Fatalf("first resize: %v", err)
+		}
+		if err := runResize(t, p, h.sock, 100, 40); err != nil {
+			t.Fatalf("second resize: %v", err)
+		}
+		if got := h.connCount(); got != 1 {
+			t.Fatalf("handler accepted %d connections, want 1 (reuse)", got)
+		}
+	})
+
+	t.Run("a handler error response is surfaced to the caller", func(t *testing.T) {
+		h := startFakeTTYHandler(t, func(h *fakeTTYHandler, conn net.Conn) {
+			serveResponses(h, conn, "1 error setting window size\n")
+		})
+
+		p := newTTYProcess(t)
+		err := runResize(t, p, h.sock, 80, 24)
+		if err == nil {
+			t.Fatal("got nil error, want the handler error")
+		}
+		if !strings.Contains(err.Error(), "error setting window size") {
+			t.Fatalf("error %q does not carry the handler message", err)
+		}
+	})
+
+	t.Run("a response fragmented across writes is reassembled", func(t *testing.T) {
+		h := startFakeTTYHandler(t, func(h *fakeTTYHandler, conn net.Conn) {
+			r := bufio.NewReader(conn)
+			for {
+				if _, ok := h.readRequest(r); !ok {
+					conn.Close()
+					return
+				}
+				// Split the ack so the client must buffer across reads to find
+				// the terminating newline.
+				conn.Write([]byte("0"))
+				time.Sleep(20 * time.Millisecond)
+				conn.Write([]byte("\n"))
+			}
+		})
+
+		p := newTTYProcess(t)
+		if err := runResize(t, p, h.sock, 80, 24); err != nil {
+			t.Fatalf("fragmented ack: %v", err)
+		}
+	})
+}
+
+func TestTTYControlClientResize(t *testing.T) {
+	t.Run("a resize on a reused connection whose deadline has elapsed still succeeds", func(t *testing.T) {
+		h := startFakeTTYHandler(t, serveAcks)
+		c := newTTYControlClient(h.sock)
+		t.Cleanup(func() { c.Close() })
+
+		if err := c.Resize(context.Background(), 80, 24); err != nil {
+			t.Fatalf("first resize: %v", err)
+		}
+
+		// Leave the cached connection with an already-elapsed deadline, as an
+		// earlier request with a short context deadline would. The next resize
+		// must set a fresh deadline rather than inherit this one.
+		c.mu.Lock()
+		c.conn.SetDeadline(time.Now().Add(-time.Hour))
+		c.mu.Unlock()
+
+		if err := c.Resize(context.Background(), 100, 40); err != nil {
+			t.Fatalf("resize after an elapsed deadline: %v", err)
+		}
+		// It reused the one connection (a bled-through deadline would have failed
+		// the exchange above instead).
+		if got := h.connCount(); got != 1 {
+			t.Fatalf("handler accepted %d connections, want 1", got)
+		}
+	})
+}
 
 func TestTTYServiceProperties(t *testing.T) {
 	tests := []struct {
@@ -60,5 +297,125 @@ func assertTTYFileProperty(t *testing.T, properties []dbus.Property, name, want 
 	}
 	if want != "" {
 		t.Fatalf("%s is omitted, want %q", name, want)
+	}
+}
+
+// ttyClientReading builds a ttyControlClient whose readMsg reads from s, wired
+// through the same reusable io.LimitedReader as a dialed client so the cap is
+// exercised.
+func ttyClientReading(s string) *ttyControlClient {
+	limit := &io.LimitedReader{R: strings.NewReader(s)}
+	return &ttyControlClient{reader: bufio.NewReader(limit), limit: limit}
+}
+
+// newTTYProcess builds the minimal process ResizePTY needs and ensures its
+// tty control client is closed when the test ends.
+func newTTYProcess(t *testing.T) *process {
+	t.Helper()
+	p := &process{Terminal: true}
+	t.Cleanup(p.closeTTYControl)
+	return p
+}
+
+// runResize runs ResizePTY with a watchdog so a hang (e.g. a lock deadlock)
+// fails the test instead of hanging the suite.
+func runResize(t *testing.T, p *process, sock string, w, h int) error {
+	t.Helper()
+	done := make(chan error, 1)
+	go func() {
+		done <- p.ResizePTY(context.Background(), w, h, sock)
+	}()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(10 * time.Second):
+		t.Fatal("ResizePTY did not return within 10s; possible lock deadlock")
+		return nil
+	}
+}
+
+// fakeTTYHandler is an in-process stand-in for the pty.c tty handler. It serves
+// the newline-framed resize protocol over a unix socket so ResizePTY can be
+// exercised end to end.
+type fakeTTYHandler struct {
+	sock string
+
+	mu       sync.Mutex
+	requests []string
+	conns    int
+}
+
+func startFakeTTYHandler(t *testing.T, serve func(h *fakeTTYHandler, conn net.Conn)) *fakeTTYHandler {
+	t.Helper()
+
+	sock := filepath.Join(t.TempDir(), "s")
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+
+	h := &fakeTTYHandler{sock: sock}
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			h.mu.Lock()
+			h.conns++
+			h.mu.Unlock()
+			serve(h, conn)
+		}
+	}()
+	return h
+}
+
+// readRequest reads one framed request from the client and records it.
+func (h *fakeTTYHandler) readRequest(r *bufio.Reader) (string, bool) {
+	line, err := r.ReadString('\n')
+	if err != nil {
+		return "", false
+	}
+	req := strings.TrimRight(line, "\n")
+	h.mu.Lock()
+	h.requests = append(h.requests, req)
+	h.mu.Unlock()
+	return req, true
+}
+
+func (h *fakeTTYHandler) lastRequest() string {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if len(h.requests) == 0 {
+		return ""
+	}
+	return h.requests[len(h.requests)-1]
+}
+
+func (h *fakeTTYHandler) connCount() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.conns
+}
+
+// serveAcks answers every request on the connection with a success ack.
+func serveAcks(h *fakeTTYHandler, conn net.Conn) {
+	serveResponses(h, conn, "0\n")
+}
+
+// serveResponses answers every request on the connection with resp until the
+// client closes it.
+func serveResponses(h *fakeTTYHandler, conn net.Conn, resp string) {
+	r := bufio.NewReader(conn)
+	for {
+		if _, ok := h.readRequest(r); !ok {
+			conn.Close()
+			return
+		}
+		if _, err := conn.Write([]byte(resp)); err != nil {
+			conn.Close()
+			return
+		}
 	}
 }


### PR DESCRIPTION
Resolves #6.

## Problem
The tty handler wrote error replies with `write(fd, msg, sizeof(msg))` — the pointer size (8 bytes), not the message — so errors reached the shim truncated or garbled, and several handler error paths fell through into the success ack. The Go client distinguished success from error only by response byte count, with no framing, and depended on the connection closing to read a reply to EOF.

## Change
- **Wire protocol:** both sides now speak a newline-framed request/response. Request `"<op> <width> <height>\n"`; reply `"0\n"` on success or `"1 <message>\n"` on error.
- **C handler:** `handle_tty_op_conn` buffers the byte stream and services each `\n`-terminated request, so a fragmented request can't desync requests from replies; error replies go through a `reply_err` helper (`snprintf`/`strlen`, no more `sizeof` bug); recoverable errors reply and keep the connection open instead of falling through into the ack/ioctl; and a client disconnect (`read` == 0) closes cleanly instead of busy-looping.
- **Go client:** the resize path is a small `ttyControlClient` exposing just `Resize`/`Close`. It has its own mutex, so an exchange no longer runs under the process lifecycle lock; reads are bounded by a deadline and an `io.LimitedReader`; the request is encoded into a fixed per-client buffer with zero allocation.

Kept deliberately lean for a transient local unit: no reconnect retry loop and no per-resize cancellation goroutine — a failed exchange just drops the connection so the next resize redials, and the deadline bounds a wedged handler without wedging the lifecycle.

## Testing
- `go test -race -short ./...` — unit tests plus client end-to-end over a real unix socket: request framing, connection reuse, handler errors surfaced, fragmented replies reassembled, fresh-deadline-on-reuse, and zero-alloc request encoding.
- `gcc -Wall` clean. The C handler's request-side reassembly is exercised by the containerd integration suite.

## Open question
- Whether to keep backward-compat acceptance of an unframed bare `"0"` from a pre-framing handler (only matters across a shim upgrade with a lingering old handler).