### PR TITLE
Add CI check that generated files are up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,3 +119,20 @@ jobs:
           set -euxo pipefail
           sudo test -S /run/systemd/private
           sudo env -u XDG_RUNTIME_DIR ./shim.test -test.v
+
+  generate:
+    runs-on: ubuntu-26.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - uses: cachix/install-nix-action@630ae543ea3a38a9a4166f03376c02c50f408342 # v31
+      - name: go generate
+        # Run generation in the flake devShell so protoc and the Go toolchain
+        # match the pinned reproducible environment.
+        run: |
+          nix develop --command go generate ./... || exit $?
+          git add -N .
+          if ! git diff --exit-code; then
+            echo "::error::Missing updates to generated files. Please run 'go generate ./...' and commit the changes"
+            exit 1
+          fi

--- a/gomod2nix.toml
+++ b/gomod2nix.toml
@@ -41,8 +41,9 @@ schema = 3
     version = "v1.1.0"
     hash = "sha256-pM2hvoAPmJBxHV6psHc7QP2y/j1Ke9z3lHrlqK4Oq7U="
   [mod."github.com/containerd/go-runc"]
-    version = "v1.1.0"
-    hash = "sha256-DvZjx2+l453Jl9MNuRkHai6tF1bNdP5BJ+YRIQlRxg0="
+    version = "v0.0.0-20260720172958-a43614f93d79"
+    hash = "sha256-QaVwJlH/abrYwIlN52vS5CqX6t43xjpt1ZqqvBGwcoo="
+    replaced = "github.com/cpuguy83/go-runc"
   [mod."github.com/containerd/log"]
     version = "v0.1.0"
     hash = "sha256-vuE6Mie2gSxiN3jTKTZovjcbdBd1YEExb7IBe3GM+9s="


### PR DESCRIPTION
Adds a `generate` CI job that runs `go generate ./...` in the flake devShell and fails if the working tree changes.

This catches stale, missing, or newly-required generated files (`gomod2nix.toml`, `options/options.pb.go`) that weren't regenerated and committed. Running inside `nix develop` ensures `protoc` and the Go toolchain match the pinned reproducible environment. New files are flagged via `git add -N .` before the diff check.