### PR TITLE
Pin GitHub Actions to commit digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,13 +22,13 @@ jobs:
       run:
         working-directory: src/github.com/cpuguy83/containerd-shim-systemd-v1
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: src/github.com/cpuguy83/containerd-shim-systemd-v1
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           path: src/github.com/containerd/containerd
           repository: containerd/containerd
@@ -75,7 +75,7 @@ jobs:
           EXTRA_TESTFLAGS: "-no-criu -no-shim-cgroup"
           GOTEST: gotestsum --format=standard-verbose --
       - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v6
+        uses: mikepenz/action-junit-report@d9f48fc87bc235f7e214acf696ca5abc0a986f16 # v6
         if: always() # always run even if the previous step fails
         with:
           report_paths: ${{github.workspace}}/junit.xml
@@ -89,12 +89,12 @@ jobs:
       - name: Show shim logs
         if: always()
         run: sudo journalctl --system --unit=containerd-shim-systemd-v1.service --no-pager
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
           name: daemon-log-${{ matrix.containerd-version }}
           path: ${{github.workspace}}/containerd-shim-systemd-v1.log
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() }}
         with:
           name: goroutines-${{ matrix.containerd-version }}
@@ -104,10 +104,10 @@ jobs:
     runs-on: ubuntu-26.04
     timeout-minutes: 15
     steps:
-      - uses: actions/setup-go@v6
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: "1.26"
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
       - name: build tests
         # Compile the race-enabled test binary as the normal user so the Go
         # toolchain and module cache are never touched as root.


### PR DESCRIPTION
Pins every action in the CI workflow to a commit SHA, with the version kept as a trailing comment.

Running actions by mutable tag means a compromised or retagged action can silently change what CI executes. Pinning by digest makes the exact action code deterministic and auditable.

- `actions/setup-go@v6` → `924ae3a`
- `actions/checkout@v7` → `3d3c42e`
- `actions/upload-artifact@v7` → `043fb46`
- `mikepenz/action-junit-report@v6` → `d9f48fc`

`actions/checkout@v7` and `cachix/install-nix-action@v31` were already pinned and are unchanged.