### PR TITLE
Add shim instrumentation and a benchmark harness vs runc.v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bin/
+bench-results/
 *.test
 result
 result-*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,8 +102,10 @@ systemd.
 ## Repository conventions
 
 - Most implementation and tests intentionally live in the root `main`
-  package; `options/` contains protobuf-generated configuration types and
-  `contrib/checkexec/` is a small integration helper.
+  package; `options/` contains protobuf-generated configuration types,
+  `contrib/checkexec/` is a small integration helper, and `contrib/bench/` is
+  the benchmark harness that compares this shim against `io.containerd.runc.v2`
+  (`make bench`; see `contrib/bench/README.md`).
 - Format Go changes with `gofmt`. Follow existing context-aware APIs, wrap
   errors with operation details, and preserve containerd's gRPC error
   translation at API boundaries.

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,37 @@ OUTPUT ?= bin
 build:
 	$(GO) build -o $(OUTPUT)/ .
 
+.PHONY: bench bench-build
+bench-build:
+	$(GO) build -o $(OUTPUT)/bench ./contrib/bench
+
+# Benchmark this shim against io.containerd.runc.v2. Requires a running
+# containerd with the shim installed against the same containerd that
+# CONTAINERD_ADDRESS points at (e.g. `make install ALL=1` for the default
+# /run/containerd), or run inside `nix run .#vm`. Reads /proc and the system
+# containerd, so it runs under sudo by default. Override any BENCH_* var or
+# CONTAINERD_ADDRESS; set BENCH_OUT to pin the output dir.
+CONTAINERD_ADDRESS ?= /run/containerd/containerd.sock
+BENCH_RUNTIMES     ?= io.containerd.runc.v2,io.containerd.systemd.v1
+BENCH_ITERATIONS   ?= 50
+BENCH_WARMUP       ?= 5
+BENCH_PARALLEL     ?= 1,4,8,16
+BENCH_SCALE_COUNTS ?= 1,5,10,25,50
+BENCH_SCENARIOS    ?= container,exec,status,container-tty,exec-tty,scale
+BENCH_SUDO         ?= sudo
+BENCH_OUT          ?=
+
+bench: bench-build
+	$(BENCH_SUDO) $(OUTPUT)/bench \
+		-containerd-address=$(CONTAINERD_ADDRESS) \
+		-runtimes=$(BENCH_RUNTIMES) \
+		-iterations=$(BENCH_ITERATIONS) \
+		-warmup=$(BENCH_WARMUP) \
+		-parallel=$(BENCH_PARALLEL) \
+		-scale-counts=$(BENCH_SCALE_COUNTS) \
+		-scenarios=$(BENCH_SCENARIOS) \
+		$(if $(BENCH_OUT),-out=$(BENCH_OUT),) $(BENCH_FLAGS)
+
 clean:
 	rm -rf $(OUTPUT)/*
 

--- a/contrib/bench/README.md
+++ b/contrib/bench/README.md
@@ -1,0 +1,97 @@
+# Shim benchmark harness
+
+Benchmarks `io.containerd.systemd.v1` against the stock `io.containerd.runc.v2`
+shim and renders the results as raw data plus glanceable charts.
+
+It drives real task-API lifecycles through the containerd Go client (the only
+thing that differs between runtimes is the `WithRuntime` string), samples
+per-process CPU and memory from `/proc`, and — for the systemd shim only —
+scrapes the expvar counters at `127.0.0.1:8089/debug/vars` to report how often
+exit state was served from the in-memory D-Bus reactor versus a systemd
+`GetAll` / on-disk fallback.
+
+## What it measures
+
+- **Latency**, per task op (create / start / run / delete / total for
+  containers; exec_create / start / run / delete / total for execs; state /
+  stats for status collection), reported as p50/p90/p99/mean/stddev.
+- **Concurrency**: every latency scenario runs at each `-parallel` degree, so
+  you see throughput and tail latency as in-flight operations rise — the axis
+  where one shared daemon (systemd) diverges from one shim per container
+  (runc.v2). Concurrent execs also run against a *single* container, the worst
+  case for the shared per-container lock.
+- **CPU & memory**, attributed by process category (systemd-shim daemon, PTY
+  helper, runc.v2 shim, runc, systemd, containerd). Memory is Pss (accounts for
+  shared pages).
+- **Footprint at scale**: peak shim memory as container count grows.
+- **TTY** as a distinct scenario (extra transient tty unit + cgo PTY copier for
+  the systemd shim).
+- **State-source fallback** (systemd shim internal diagnostic).
+
+## Running it
+
+The harness needs a running containerd with both runtimes registered, root
+(reads `/proc` and the root-owned containerd socket), and the image pre-pullable.
+
+### Canonical: the NixOS VM (both runtimes present, isolated, reproducible)
+
+```console
+nix run .#vm
+# then, at the VM's root console:
+bench -runtimes=io.containerd.systemd.v1,io.containerd.runc.v2
+```
+
+`bench` is on the VM PATH (built as a subpackage of the flake). Results land in
+`bench-results/<timestamp>/` in the VM; copy them out or open `report.html`.
+
+Absolute latency inside a VM includes virtualization overhead — the numbers are
+meaningful as *relative* shim-vs-shim comparison.
+
+### Host: `make bench`
+
+Install the systemd shim into containerd's PATH and register its units, then
+point `CONTAINERD_ADDRESS` at the containerd it was installed against — the shim
+publishes task events to that containerd, so a mismatch misroutes systemd-shim
+events and distorts the comparison. Against the default node containerd:
+
+```console
+make install ALL=1     # builds, installs the binary onto PATH, registers units (publisher /run/containerd)
+make bench             # CONTAINERD_ADDRESS defaults to /run/containerd
+```
+
+To use a separate test containerd (as CI does with `make test-daemon`, which
+installs the shim at `/run/containerd-test`), benchmark against that same
+address:
+
+```console
+make test-daemon
+make bench CONTAINERD_ADDRESS=/run/containerd-test/containerd.sock
+```
+
+Override `CONTAINERD_ADDRESS`, `BENCH_RUNTIMES`, `BENCH_ITERATIONS`,
+`BENCH_WARMUP`, `BENCH_PARALLEL`, `BENCH_SCALE_COUNTS`, `BENCH_SCENARIOS`,
+`BENCH_OUT`, or pass extra flags via `BENCH_FLAGS`.
+
+Run `bench -h` for the full flag list.
+
+## Output
+
+Written to the output dir:
+
+| File | Contents |
+|------|----------|
+| `report.html` | Self-contained (inline SVG charts + data table), offline, light/dark |
+| `results.json` | Full structured results (every cell, op, sample, counter) |
+| `latency.csv` | One row per (scenario, runtime, variant, parallel, scale, op) |
+| `resources.csv` | Per-cell CPU-seconds, peak Pss, and state-source counters by category |
+| `env.json` | Provenance (kernel, containerd/runc versions, cgroup, CPU/mem, commit) |
+
+## Reading the numbers
+
+The systemd shim is one node-wide daemon (plus systemd supervision, plus a PTY
+helper per TTY workload); runc.v2 is one shim process per container. The report's
+"shim cpu"/"shim peak" columns sum the shim-attributable categories for each
+design. systemd's own CPU is shared with the system and therefore approximate;
+short-lived runc CPU may be undercounted by the sampling interval but largely
+cancels since both runtimes invoke runc. See the caveats section rendered in the
+report.

--- a/contrib/bench/charts.go
+++ b/contrib/bench/charts.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"math"
+	"slices"
+	"strings"
+)
+
+// SVG chart primitives. Charts are generated as inline SVG that reference CSS
+// custom properties (defined in the report's <style>) so a single light/dark
+// theme swap recolors everything. Every mark carries a <title> for a native
+// hover tooltip; every chart is paired with a data table in the report for the
+// color-blind / print / raw-figures case.
+
+const (
+	chartW = 760
+	chartH = 380
+	marL   = 64
+	marR   = 24
+	marT   = 28
+	marB   = 74
+)
+
+func plotW() float64 { return chartW - marL - marR }
+func plotH() float64 { return chartH - marT - marB }
+
+// catColors is the fixed categorical order from the validated reference palette
+// (blue, green, magenta, yellow, aqua, orange), mapped to CSS vars.
+var catColors = []string{
+	"var(--cat-1)", "var(--cat-2)", "var(--cat-3)",
+	"var(--cat-4)", "var(--cat-5)", "var(--cat-6)",
+}
+
+type barGroup struct {
+	name   string
+	color  string
+	values []float64 // one per category
+}
+
+// groupedBars renders categories on x with one bar per group in each category.
+func groupedBars(title, yLabel string, cats []string, groups []barGroup) string {
+	var maxVal float64
+	for _, g := range groups {
+		if len(g.values) > 0 {
+			maxVal = max(maxVal, slices.Max(g.values))
+		}
+	}
+	maxVal = niceMax(maxVal)
+
+	var b strings.Builder
+	svgOpen(&b, title)
+	drawAxes(&b, yLabel, maxVal, 5)
+
+	n := len(cats)
+	if n == 0 {
+		n = 1
+	}
+	slotW := plotW() / float64(n)
+	gw := len(groups)
+	if gw == 0 {
+		gw = 1
+	}
+	// leave ~22% of the slot as padding between category clusters
+	clusterW := slotW * 0.78
+	barW := (clusterW - float64(gw-1)*2) / float64(gw)
+	if barW < 1 {
+		barW = 1
+	}
+	showLabels := n*gw <= 20
+
+	for ci, cat := range cats {
+		slotX := marL + float64(ci)*slotW
+		clusterX := slotX + (slotW-clusterW)/2
+		for gi, g := range groups {
+			if ci >= len(g.values) {
+				continue
+			}
+			v := g.values[ci]
+			bh := v / maxVal * plotH()
+			x := clusterX + float64(gi)*(barW+2)
+			y := marT + plotH() - bh
+			tip := fmt.Sprintf("%s — %s: %s", cat, g.name, fmtNum(v))
+			fmt.Fprintf(&b, `<path d="%s" fill="%s"><title>%s</title></path>`,
+				roundedTopRect(x, y, barW, bh, 3), g.color, html.EscapeString(tip))
+			if showLabels && bh > 12 {
+				fmt.Fprintf(&b, `<text x="%.1f" y="%.1f" text-anchor="middle" class="vlabel">%s</text>`,
+					x+barW/2, y-4, fmtNum(v))
+			}
+		}
+		fmt.Fprintf(&b, `<text x="%.1f" y="%.1f" text-anchor="middle" class="xlabel">%s</text>`,
+			slotX+slotW/2, marT+plotH()+16, html.EscapeString(cat))
+	}
+
+	legend(&b, groupLegend(groups))
+	b.WriteString("</svg>")
+	return b.String()
+}
+
+type linePoint struct {
+	label   string
+	y       float64
+	missing bool // no data for this x: skip the marker and break the line
+}
+
+type lineSeries struct {
+	name   string
+	color  string
+	points []linePoint
+}
+
+// lineChart renders discrete x levels (evenly spaced by index) with one polyline
+// per series. Used for throughput/tail-latency vs parallelism and memory vs N.
+func lineChart(title, yLabel string, xLabels []string, series []lineSeries) string {
+	var maxVal float64
+	for _, s := range series {
+		for _, p := range s.points {
+			maxVal = max(maxVal, p.y)
+		}
+	}
+	maxVal = niceMax(maxVal)
+
+	var b strings.Builder
+	svgOpen(&b, title)
+	drawAxes(&b, yLabel, maxVal, 5)
+
+	n := len(xLabels)
+	step := plotW()
+	if n > 1 {
+		step = plotW() / float64(n-1)
+	}
+	xAt := func(i int) float64 { return marL + float64(i)*step }
+	yAt := func(v float64) float64 { return marT + plotH() - v/maxVal*plotH() }
+
+	for i, lbl := range xLabels {
+		fmt.Fprintf(&b, `<text x="%.1f" y="%.1f" text-anchor="middle" class="xlabel">%s</text>`,
+			xAt(i), marT+plotH()+16, html.EscapeString(lbl))
+	}
+
+	for _, s := range series {
+		// Draw the line in segments, breaking at points with no data so a
+		// missing cell reads as a gap rather than a dip to zero.
+		var seg []string
+		flush := func() {
+			if len(seg) >= 2 {
+				fmt.Fprintf(&b, `<polyline points="%s" fill="none" stroke="%s" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>`,
+					strings.Join(seg, " "), s.color)
+			}
+			seg = seg[:0]
+		}
+		for i, p := range s.points {
+			if p.missing {
+				flush()
+				continue
+			}
+			seg = append(seg, fmt.Sprintf("%.1f,%.1f", xAt(i), yAt(p.y)))
+		}
+		flush()
+		for i, p := range s.points {
+			if p.missing {
+				continue
+			}
+			tip := fmt.Sprintf("%s @ %s: %s", s.name, p.label, fmtNum(p.y))
+			fmt.Fprintf(&b, `<circle cx="%.1f" cy="%.1f" r="4" fill="%s" stroke="var(--surface-1)" stroke-width="1.5"><title>%s</title></circle>`,
+				xAt(i), yAt(p.y), s.color, html.EscapeString(tip))
+		}
+	}
+
+	legend(&b, seriesLegend(series))
+	b.WriteString("</svg>")
+	return b.String()
+}
+
+type stackSeg struct {
+	name   string
+	color  string
+	values []float64 // one per category (x)
+}
+
+// stackedBars renders one stacked bar per category, segments in fixed order.
+func stackedBars(title, yLabel string, cats []string, segs []stackSeg) string {
+	totals := make([]float64, len(cats))
+	for _, s := range segs {
+		for i, v := range s.values {
+			if i < len(totals) {
+				totals[i] += v
+			}
+		}
+	}
+	var maxVal float64
+	if len(totals) > 0 {
+		maxVal = slices.Max(totals)
+	}
+	maxVal = niceMax(maxVal)
+
+	var b strings.Builder
+	svgOpen(&b, title)
+	drawAxes(&b, yLabel, maxVal, 5)
+
+	n := len(cats)
+	if n == 0 {
+		n = 1
+	}
+	slotW := plotW() / float64(n)
+	barW := min(slotW*0.5, 90)
+
+	for ci, cat := range cats {
+		x := marL + float64(ci)*slotW + (slotW-barW)/2
+		var acc float64
+		for _, s := range segs {
+			if ci >= len(s.values) {
+				continue
+			}
+			v := s.values[ci]
+			if v <= 0 {
+				continue
+			}
+			segH := v / maxVal * plotH()
+			y := marT + plotH() - (acc+v)/maxVal*plotH()
+			// 2px surface gap between segments
+			gap := 1.0
+			tip := fmt.Sprintf("%s — %s: %s", cat, s.name, fmtNum(v))
+			fmt.Fprintf(&b, `<rect x="%.1f" y="%.1f" width="%.1f" height="%.1f" rx="2" fill="%s"><title>%s</title></rect>`,
+				x, y+gap, barW, max(segH-2*gap, 0.5), s.color, html.EscapeString(tip))
+			acc += v
+		}
+		fmt.Fprintf(&b, `<text x="%.1f" y="%.1f" text-anchor="middle" class="xlabel">%s</text>`,
+			x+barW/2, marT+plotH()+16, html.EscapeString(cat))
+	}
+
+	legend(&b, stackLegend(segs))
+	b.WriteString("</svg>")
+	return b.String()
+}
+
+func svgOpen(b *strings.Builder, title string) {
+	fmt.Fprintf(b, `<svg viewBox="0 0 %d %d" role="img" aria-label="%s" class="chart">`,
+		chartW, chartH, html.EscapeString(title))
+}
+
+func drawAxes(b *strings.Builder, yLabel string, maxVal float64, ticks int) {
+	// gridlines + y ticks
+	for i := 0; i <= ticks; i++ {
+		v := maxVal * float64(i) / float64(ticks)
+		y := marT + plotH() - float64(i)/float64(ticks)*plotH()
+		fmt.Fprintf(b, `<line x1="%d" y1="%.1f" x2="%.1f" y2="%.1f" class="grid"/>`,
+			marL, y, marL+plotW(), y)
+		fmt.Fprintf(b, `<text x="%d" y="%.1f" text-anchor="end" class="ytick">%s</text>`,
+			marL-8, y+3, fmtNum(v))
+	}
+	// baseline
+	fmt.Fprintf(b, `<line x1="%d" y1="%.1f" x2="%.1f" y2="%.1f" class="axis"/>`,
+		marL, marT+plotH(), marL+plotW(), marT+plotH())
+	if yLabel != "" {
+		fmt.Fprintf(b, `<text x="%d" y="%d" class="axislabel">%s</text>`, 6, marT-12, html.EscapeString(yLabel))
+	}
+}
+
+type legendItem struct {
+	name  string
+	color string
+}
+
+func groupLegend(groups []barGroup) []legendItem {
+	items := make([]legendItem, len(groups))
+	for i, g := range groups {
+		items[i] = legendItem{g.name, g.color}
+	}
+	return items
+}
+
+func seriesLegend(series []lineSeries) []legendItem {
+	items := make([]legendItem, len(series))
+	for i, s := range series {
+		items[i] = legendItem{s.name, s.color}
+	}
+	return items
+}
+
+func stackLegend(segs []stackSeg) []legendItem {
+	items := make([]legendItem, len(segs))
+	for i, s := range segs {
+		items[i] = legendItem{s.name, s.color}
+	}
+	return items
+}
+
+func legend(b *strings.Builder, items []legendItem) {
+	y := float64(chartH - 28)
+	x := float64(marL)
+	for _, it := range items {
+		fmt.Fprintf(b, `<rect x="%.1f" y="%.1f" width="11" height="11" rx="2" fill="%s"/>`, x, y, it.color)
+		fmt.Fprintf(b, `<text x="%.1f" y="%.1f" class="legend">%s</text>`, x+16, y+10, html.EscapeString(it.name))
+		x += 20 + float64(len(it.name))*7.2 + 16
+	}
+}
+
+func roundedTopRect(x, y, w, h, r float64) string {
+	if h <= 0 {
+		h = 0.5
+	}
+	if r > w/2 {
+		r = w / 2
+	}
+	if r > h {
+		r = h
+	}
+	return fmt.Sprintf("M%.1f %.1f V%.1f Q%.1f %.1f %.1f %.1f H%.1f Q%.1f %.1f %.1f %.1f V%.1f Z",
+		x, y+h,
+		y+r,
+		x, y, x+r, y,
+		x+w-r,
+		x+w, y, x+w, y+r,
+		y+h)
+}
+
+func niceMax(v float64) float64 {
+	if v <= 0 {
+		return 1
+	}
+	exp := math.Floor(math.Log10(v))
+	base := math.Pow(10, exp)
+	frac := v / base
+	var nice float64
+	switch {
+	case frac <= 1:
+		nice = 1
+	case frac <= 2:
+		nice = 2
+	case frac <= 5:
+		nice = 5
+	default:
+		nice = 10
+	}
+	return nice * base
+}
+
+func fmtNum(v float64) string {
+	switch {
+	case v == 0:
+		return "0"
+	case v >= 1000:
+		return fmt.Sprintf("%.0f", v)
+	case v >= 100:
+		return fmt.Sprintf("%.0f", v)
+	case v >= 10:
+		return fmt.Sprintf("%.1f", v)
+	default:
+		return fmt.Sprintf("%.2f", v)
+	}
+}

--- a/contrib/bench/driver.go
+++ b/contrib/bench/driver.go
@@ -1,0 +1,324 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/containerd/console"
+	containerd "github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/pkg/cio"
+	"github.com/containerd/containerd/v2/pkg/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// driver drives container/exec lifecycles through the containerd client. The
+// only thing that varies between the two runtimes under test is the runtime
+// string passed to WithRuntime, so every measured path is identical otherwise.
+type driver struct {
+	client *containerd.Client
+	image  containerd.Image
+	cfg    Config
+	seq    atomic.Int64
+}
+
+func newDriver(ctx context.Context, cfg Config) (*driver, error) {
+	// WithDefaultNamespace installs the client's namespace interceptor, which
+	// supplies the namespace to every call whose context lacks one — so cleanup
+	// contexts don't each have to carry it.
+	client, err := containerd.New(cfg.Address, containerd.WithDefaultNamespace(cfg.Namespace))
+	if err != nil {
+		return nil, fmt.Errorf("connect containerd at %s: %w", cfg.Address, err)
+	}
+	img, err := client.Pull(ctx, cfg.Image, containerd.WithPullUnpack)
+	if err != nil {
+		return nil, fmt.Errorf("pull %s: %w", cfg.Image, err)
+	}
+	return &driver{client: client, image: img, cfg: cfg}, nil
+}
+
+func (d *driver) close() error { return d.client.Close() }
+
+// benchIDPrefix namespaces every container/exec ID this harness creates, so
+// cleanup can safely target only its own containers (see cleanupNamespace).
+const benchIDPrefix = "bench-"
+
+func (d *driver) uid(prefix string) string {
+	return fmt.Sprintf("%s%s-%d", benchIDPrefix, prefix, d.seq.Add(1))
+}
+
+func msSince(t time.Time) float64 {
+	return float64(time.Since(t).Microseconds()) / 1000.0
+}
+
+// killAndDelete force-kills a process, waits (bounded) for it to exit, then
+// deletes it. Best-effort cleanup for error paths: a bare Kill+Delete races
+// because Delete rejects a still-running process.
+func killAndDelete(ctx context.Context, p containerd.Process) {
+	ctx = context.WithoutCancel(ctx)
+	waitCh, _ := p.Wait(ctx)
+	p.Kill(ctx, 9)
+	if waitCh != nil {
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+		}
+	}
+	p.Delete(ctx)
+}
+
+// ---- IO ----------------------------------------------------------------
+
+// newIO returns a cio.Creator for the workload. For TTY workloads it allocates
+// a real pty (mirroring how ctr passes the controlling terminal) and drains the
+// slave so the shim's copier never blocks. The returned cleanup closes the pty.
+func newIO(tty bool) (cio.Creator, func(), error) {
+	if !tty {
+		return cio.NullIO, func() {}, nil
+	}
+	master, slavePath, err := console.NewPty()
+	if err != nil {
+		return nil, nil, fmt.Errorf("allocate pty: %w", err)
+	}
+	slave, err := os.OpenFile(slavePath, os.O_RDWR, 0)
+	if err != nil {
+		master.Close()
+		return nil, nil, fmt.Errorf("open pty slave: %w", err)
+	}
+	go io.Copy(io.Discard, slave)
+	creator := cio.NewCreator(cio.WithStreams(master, master, nil), cio.WithTerminal)
+	cleanup := func() {
+		slave.Close()
+		master.Close()
+	}
+	return creator, cleanup, nil
+}
+
+func (d *driver) newContainer(ctx context.Context, rt, id string, tty bool, args []string) (containerd.Container, error) {
+	specOpts := []oci.SpecOpts{oci.WithImageConfig(d.image), oci.WithProcessArgs(args...)}
+	if tty {
+		specOpts = append(specOpts, oci.WithTTY)
+	}
+	return d.client.NewContainer(ctx, id,
+		containerd.WithImage(d.image),
+		containerd.WithNewSnapshot(id, d.image),
+		containerd.WithRuntime(rt, nil),
+		containerd.WithNewSpec(specOpts...),
+	)
+}
+
+// containerLifecycle runs one short-lived container end to end and returns the
+// per-op latencies in ms. Cleanup is best-effort on every path.
+func (d *driver) containerLifecycle(ctx context.Context, rt string, tty bool) (map[string]float64, error) {
+	ops := map[string]float64{}
+	id := d.uid("ctr")
+
+	ioc, cleanup, err := newIO(tty)
+	if err != nil {
+		return ops, err
+	}
+	defer cleanup()
+
+	t0 := time.Now()
+	c, err := d.newContainer(ctx, rt, id, tty, []string{"/bin/true"})
+	ops["container_new"] = msSince(t0)
+	if err != nil {
+		return ops, err
+	}
+	deleted := false
+	defer func() {
+		if !deleted {
+			c.Delete(context.WithoutCancel(ctx), containerd.WithSnapshotCleanup)
+		}
+	}()
+
+	t1 := time.Now()
+	task, err := c.NewTask(ctx, ioc)
+	ops["create"] = msSince(t1)
+	if err != nil {
+		return ops, err
+	}
+	taskDeleted := false
+	defer func() {
+		if !taskDeleted {
+			killAndDelete(ctx, task)
+		}
+	}()
+
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		return ops, err
+	}
+
+	t2 := time.Now()
+	if err := task.Start(ctx); err != nil {
+		return ops, err
+	}
+	ops["start"] = msSince(t2)
+
+	tRun := time.Now()
+	select {
+	case st := <-statusC:
+		ops["run"] = msSince(tRun)
+		if code, _, err := st.Result(); err != nil {
+			return ops, err
+		} else if code != 0 {
+			return ops, fmt.Errorf("container %s exited %d", id, code)
+		}
+	case <-ctx.Done():
+		return ops, ctx.Err()
+	}
+
+	t3 := time.Now()
+	if _, err := task.Delete(ctx); err != nil {
+		return ops, err
+	}
+	taskDeleted = true
+	ops["delete"] = msSince(t3)
+
+	t4 := time.Now()
+	if err := c.Delete(ctx, containerd.WithSnapshotCleanup); err != nil {
+		return ops, err
+	}
+	deleted = true
+	ops["container_delete"] = msSince(t4)
+
+	ops["total"] = ops["create"] + ops["start"] + ops["run"] + ops["delete"]
+	return ops, nil
+}
+
+// longContainer creates and starts a long-running container (sleep) and returns
+// a teardown func. Used as the target of exec/status scenarios.
+func (d *driver) longContainer(ctx context.Context, rt, id string) (containerd.Task, func(), error) {
+	c, err := d.newContainer(ctx, rt, id, false, []string{"/bin/sleep", "3600"})
+	if err != nil {
+		return nil, nil, err
+	}
+	task, err := c.NewTask(ctx, cio.NullIO)
+	if err != nil {
+		c.Delete(context.WithoutCancel(ctx), containerd.WithSnapshotCleanup)
+		return nil, nil, err
+	}
+	statusC, err := task.Wait(ctx)
+	if err != nil {
+		task.Delete(context.WithoutCancel(ctx))
+		c.Delete(context.WithoutCancel(ctx), containerd.WithSnapshotCleanup)
+		return nil, nil, err
+	}
+	if err := task.Start(ctx); err != nil {
+		task.Delete(context.WithoutCancel(ctx))
+		c.Delete(context.WithoutCancel(ctx), containerd.WithSnapshotCleanup)
+		return nil, nil, err
+	}
+	teardown := func() {
+		bg := context.WithoutCancel(ctx)
+		task.Kill(bg, 9)
+		select {
+		case <-statusC:
+		case <-time.After(5 * time.Second):
+		}
+		task.Delete(bg)
+		c.Delete(bg, containerd.WithSnapshotCleanup)
+	}
+	return task, teardown, nil
+}
+
+// execOnce runs one short-lived exec against an existing task.
+func (d *driver) execOnce(ctx context.Context, task containerd.Task, tty bool) (map[string]float64, error) {
+	ops := map[string]float64{}
+	ioc, cleanup, err := newIO(tty)
+	if err != nil {
+		return ops, err
+	}
+	defer cleanup()
+
+	spec := &specs.Process{Args: []string{"/bin/true"}, Cwd: "/", Terminal: tty}
+	execID := d.uid("exec")
+
+	t0 := time.Now()
+	p, err := task.Exec(ctx, execID, spec, ioc)
+	ops["exec_create"] = msSince(t0)
+	if err != nil {
+		return ops, err
+	}
+	deleted := false
+	defer func() {
+		if !deleted {
+			killAndDelete(ctx, p)
+		}
+	}()
+
+	statusC, err := p.Wait(ctx)
+	if err != nil {
+		return ops, err
+	}
+
+	t1 := time.Now()
+	if err := p.Start(ctx); err != nil {
+		return ops, err
+	}
+	ops["start"] = msSince(t1)
+
+	tRun := time.Now()
+	select {
+	case st := <-statusC:
+		ops["run"] = msSince(tRun)
+		if code, _, err := st.Result(); err != nil {
+			return ops, err
+		} else if code != 0 {
+			return ops, fmt.Errorf("exec %s exited %d", execID, code)
+		}
+	case <-ctx.Done():
+		return ops, ctx.Err()
+	}
+
+	t2 := time.Now()
+	if _, err := p.Delete(ctx); err != nil {
+		return ops, err
+	}
+	deleted = true
+	ops["delete"] = msSince(t2)
+
+	ops["total"] = ops["exec_create"] + ops["start"] + ops["run"] + ops["delete"]
+	return ops, nil
+}
+
+// runConcurrentN runs fn total times with at most parallel in flight, returning
+// the merged per-op latency samples, the error count, and total wall time.
+func runConcurrentN(total, parallel int, fn func() (map[string]float64, error)) (map[string][]float64, int, time.Duration) {
+	if parallel < 1 {
+		parallel = 1
+	}
+	sem := make(chan struct{}, parallel)
+	var (
+		mu   sync.Mutex
+		raw  = map[string][]float64{}
+		errs int
+		wg   sync.WaitGroup
+	)
+
+	start := time.Now()
+	for range total {
+		sem <- struct{}{}
+
+		wg.Go(func() {
+			defer func() { <-sem }()
+			ops, err := fn()
+			mu.Lock()
+			if err != nil {
+				errs++
+			}
+			for k, v := range ops {
+				raw[k] = append(raw[k], v)
+			}
+			mu.Unlock()
+		})
+	}
+
+	wg.Wait()
+	return raw, errs, time.Since(start)
+}

--- a/contrib/bench/html.go
+++ b/contrib/bench/html.go
@@ -1,0 +1,503 @@
+package main
+
+import (
+	"fmt"
+	"html"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+func writeHTML(path string, r *Report) error {
+	var b strings.Builder
+	b.WriteString("<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">")
+	b.WriteString(`<meta name="viewport" content="width=device-width, initial-scale=1">`)
+	b.WriteString("<title>Shim benchmark — systemd vs runc.v2</title>")
+	b.WriteString("<style>" + reportCSS + "</style></head><body class=\"viz\">")
+
+	b.WriteString(`<header class="top"><div><h1>containerd shim benchmark</h1>`)
+	b.WriteString(`<p class="sub">io.containerd.systemd.v1 vs io.containerd.runc.v2</p></div>`)
+	b.WriteString(`<button id="themeToggle" class="toggle" type="button">◐ theme</button></header>`)
+
+	writeProvenance(&b, r)
+	writeCharts(&b, r)
+	writeDataTable(&b, r)
+	writeCaveats(&b)
+
+	b.WriteString(`<script>` + themeJS + `</script>`)
+	b.WriteString("</body></html>")
+
+	return os.WriteFile(path, []byte(b.String()), 0o644)
+}
+
+func writeProvenance(b *strings.Builder, r *Report) {
+	e := r.Env
+	rows := [][2]string{
+		{"started", r.StartedAt},
+		{"host", e.Hostname},
+		{"kernel", e.Kernel},
+		{"arch", e.Arch},
+		{"cpus", strconv.Itoa(e.NumCPU)},
+		{"memory", fmtBytes(e.MemTotalBytes)},
+		{"cgroup", e.CgroupVersion},
+		{"containerd", e.ContainerdVer},
+		{"runc", e.RuncVersion},
+		{"go", e.GoVersion},
+		{"harness commit", short(e.HarnessGitCommit, 12)},
+		{"inside VM", fmt.Sprintf("%v", e.InsideVM)},
+		{"iterations", strconv.Itoa(r.Config.Iterations)},
+		{"warmup", strconv.Itoa(r.Config.Warmup)},
+		{"parallel", joinInts(r.Config.Parallel)},
+		{"scale counts", joinInts(r.Config.ScaleCounts)},
+		{"image", r.Config.Image},
+	}
+	b.WriteString(`<section class="prov"><h2>environment</h2><dl>`)
+	for _, kv := range rows {
+		if kv[1] == "" {
+			continue
+		}
+		fmt.Fprintf(b, `<div><dt>%s</dt><dd>%s</dd></div>`, html.EscapeString(kv[0]), html.EscapeString(kv[1]))
+	}
+	b.WriteString(`</dl></section>`)
+}
+
+func writeCharts(b *strings.Builder, r *Report) {
+	rts := r.runtimesPresent()
+	maxP := slices.Max(r.Config.Parallel)
+
+	section := func(title, desc, svg string) {
+		if svg == "" {
+			return
+		}
+		fmt.Fprintf(b, `<figure class="card"><figcaption><h3>%s</h3><p>%s</p></figcaption>%s</figure>`,
+			html.EscapeString(title), html.EscapeString(desc), svg)
+	}
+
+	b.WriteString(`<section class="charts">`)
+
+	// Latency — container & exec per-op, sequential baseline (p=1).
+	section("Container run latency (p50, sequential)",
+		"Time for each task op across a full container lifecycle. Lower is better.",
+		chartPerOp(r, "container", "", 1, []string{"create", "start", "run", "delete", "total"}, "ms"))
+	section("Exec latency (p50, sequential)",
+		"Time to run a short exec inside a running container.",
+		chartPerOp(r, "exec", "spread", 1, []string{"exec_create", "start", "run", "delete", "total"}, "ms"))
+	section("Status collection latency (p50, sequential)",
+		"State (task status) and Stats (cgroup metrics) call latency.",
+		chartPerOp(r, "status", "", 1, []string{"state", "stats"}, "ms"))
+
+	// TTY vs non-TTY.
+	section("TTY vs non-TTY total latency (p50, sequential)",
+		"The TTY path adds a transient tty unit + PTY-copy helper for the systemd shim.",
+		chartTTY(r))
+
+	// Concurrency.
+	section("Throughput vs parallelism — container",
+		"Container lifecycles completed per second as in-flight concurrency rises.",
+		chartVsParallel(r, "container", "", "throughput", "ops/sec"))
+	section("Tail latency (p99) vs parallelism — container",
+		"p99 of end-to-end container latency under concurrency. Watch the shared-daemon tail.",
+		chartVsParallel(r, "container", "", "p99", "ms"))
+	section("Tail latency (p99) vs parallelism — exec on one container",
+		"Concurrent execs against a single container — worst case for the shared per-container lock.",
+		chartVsParallel(r, "exec", "single-container", "p99", "ms"))
+
+	// Footprint.
+	section("Shim memory vs container count (peak Pss)",
+		"Resident shim memory as containers scale: one shared daemon vs one shim per container.",
+		chartScaleMem(r))
+
+	// CPU — fair headline (lifetime-independent) then per-process breakdown.
+	section("Server CPU per container (system − harness)",
+		"System-wide CPU-seconds over the run minus the harness's own, per container. Lifetime-independent, so short-lived runc is counted — this is the fair CPU comparison.",
+		chartAttribCPU(r, "container"))
+	section(fmt.Sprintf("CPU by process category — container @ p=%d (breakdown)", maxP),
+		"Per-process attribution. Long-lived (shim daemon, PID1, containerd) is exact; short-lived runc / per-container shims are undercounted by sampling — use the fair total above.",
+		chartCPUByCategory(r, maxP))
+	section("systemd daemon-reload time per container op",
+		"Time in systemd daemon-reload (re-parses every unit), which the shim issues on each create and delete. ms per lifecycle.",
+		chartReload(r))
+
+	// Shim-internal fallback (systemd only).
+	section("Exit-state source: reactor vs GetAll (systemd shim)",
+		"Exit-state loads served by the in-memory D-Bus reactor vs the systemd GetAll fallback (hit rate = reactor ÷ (reactor+GetAll)). On-disk reads are a separate LoadState path, shown for volume — not part of the hit rate.",
+		chartFallback(r))
+
+	b.WriteString(`</section>`)
+	_ = rts
+}
+
+// ---- individual chart builders ----------------------------------------
+
+func chartPerOp(r *Report, scenario, variant string, parallel int, ops []string, yl string) string {
+	var groups []barGroup
+	any := false
+	labels := prettyOps(ops)
+	for _, rt := range r.runtimesPresent() {
+		s := r.find(scenario, rt, variant, parallel, 0)
+		if s == nil {
+			continue
+		}
+		any = true
+		vals := make([]float64, len(ops))
+		for i, op := range ops {
+			vals[i] = p50Op(s, op)
+		}
+		groups = append(groups, barGroup{rtShort(rt), rtColor(rt), vals})
+	}
+	if !any {
+		return ""
+	}
+	return groupedBars(scenario, yl, labels, groups)
+}
+
+func chartTTY(r *Report) string {
+	cats := []string{"container", "container-tty", "exec", "exec-tty"}
+	variants := []string{"", "", "spread", "spread"}
+	var groups []barGroup
+	any := false
+	for _, rt := range r.runtimesPresent() {
+		vals := make([]float64, len(cats))
+		for i, sc := range cats {
+			if s := r.find(sc, rt, variants[i], 1, 0); s != nil {
+				vals[i] = p50Op(s, "total")
+				any = true
+			}
+		}
+		groups = append(groups, barGroup{rtShort(rt), rtColor(rt), vals})
+	}
+	if !any {
+		return ""
+	}
+	return groupedBars("tty", "ms", cats, groups)
+}
+
+func chartVsParallel(r *Report, scenario, variant, metric, yl string) string {
+	xs := r.Config.Parallel
+	var xlabels []string
+	for _, p := range xs {
+		xlabels = append(xlabels, "p="+strconv.Itoa(p))
+	}
+	var series []lineSeries
+	any := false
+	for _, rt := range r.runtimesPresent() {
+		var pts []linePoint
+		for _, p := range xs {
+			s := r.find(scenario, rt, variant, p, 0)
+			var y float64
+			switch metric {
+			case "throughput":
+				if s != nil {
+					y = s.ThroughputOpsPerSec
+					any = true
+				}
+			case "p99":
+				y = p99Op(s, "total")
+				if s != nil {
+					any = true
+				}
+			}
+			pts = append(pts, linePoint{label: "p=" + strconv.Itoa(p), y: y, missing: s == nil})
+		}
+		series = append(series, lineSeries{rtShort(rt), rtColor(rt), pts})
+	}
+	if !any {
+		return ""
+	}
+	return lineChart(scenario, yl, xlabels, series)
+}
+
+func chartScaleMem(r *Report) string {
+	xs := r.Config.ScaleCounts
+	if len(xs) == 0 {
+		return ""
+	}
+	var xlabels []string
+	for _, n := range xs {
+		xlabels = append(xlabels, strconv.Itoa(n))
+	}
+	shimCat := map[string]string{runtimeSystemd: "shim-systemd", runtimeRunc: "shim-runc"}
+	var series []lineSeries
+	any := false
+	for _, rt := range r.runtimesPresent() {
+		cat := shimCat[rt]
+		var pts []linePoint
+		for _, n := range xs {
+			s := r.find("scale", rt, "", 0, n)
+			var y float64
+			if s != nil {
+				y = float64(s.MemPeakPss[cat]) / (1024 * 1024)
+				any = true
+			}
+			pts = append(pts, linePoint{label: strconv.Itoa(n), y: y, missing: s == nil})
+		}
+		series = append(series, lineSeries{rtShort(rt), rtColor(rt), pts})
+	}
+	if !any {
+		return ""
+	}
+	return lineChart("scale", "MB", xlabels, series)
+}
+
+func chartCPUByCategory(r *Report, parallel int) string {
+	rts := r.runtimesPresent()
+	var cats []string
+	for _, rt := range rts {
+		cats = append(cats, rtShort(rt))
+	}
+	var segs []stackSeg
+	any := false
+	for ci, c := range sampledCategories {
+		vals := make([]float64, len(rts))
+		nonzero := false
+		for i, rt := range rts {
+			if s := r.find("container", rt, "", parallel, 0); s != nil {
+				vals[i] = s.CPUSeconds[string(c)]
+				if vals[i] > 0 {
+					nonzero = true
+					any = true
+				}
+			}
+		}
+		if nonzero {
+			segs = append(segs, stackSeg{string(c), catColors[ci%len(catColors)], vals})
+		}
+	}
+	if !any {
+		return ""
+	}
+	return stackedBars("cpu", "CPU-seconds", cats, segs)
+}
+
+func chartAttribCPU(r *Report, scenario string) string {
+	var cats []string
+	for _, p := range r.Config.Parallel {
+		cats = append(cats, "p="+strconv.Itoa(p))
+	}
+	var groups []barGroup
+	any := false
+	for _, rt := range r.runtimesPresent() {
+		vals := make([]float64, len(r.Config.Parallel))
+		for i, p := range r.Config.Parallel {
+			if s := r.find(scenario, rt, "", p, 0); s != nil && s.Iterations > 0 {
+				vals[i] = s.AttribCPUSeconds / float64(s.Iterations) * 1000
+				any = true
+			}
+		}
+		groups = append(groups, barGroup{rtShort(rt), rtColor(rt), vals})
+	}
+	if !any {
+		return ""
+	}
+	return groupedBars("cpu/op", "ms/op", cats, groups)
+}
+
+func chartReload(r *Report) string {
+	order := []string{"container", "exec", "container-tty", "exec-tty", "status", "scale"}
+	type agg struct {
+		ms    float64
+		iters int
+	}
+	sums := map[string]*agg{}
+	for i := range r.Scenarios {
+		s := &r.Scenarios[i]
+		if s.Runtime != runtimeSystemd || s.ShimVars == nil {
+			continue
+		}
+		a := sums[s.Scenario]
+		if a == nil {
+			a = &agg{}
+			sums[s.Scenario] = a
+		}
+		a.ms += s.ShimVars.ReloadTotalMs
+		a.iters += s.Iterations
+	}
+	var cats []string
+	var vals []float64
+	for _, name := range order {
+		if a, ok := sums[name]; ok && a.iters > 0 {
+			cats = append(cats, name)
+			vals = append(vals, a.ms/float64(a.iters))
+		}
+	}
+	if len(cats) == 0 {
+		return ""
+	}
+	return groupedBars("reload", "ms/op", cats, []barGroup{{"systemd daemon-reload", "var(--cat-6)", vals}})
+}
+
+func chartFallback(r *Report) string {
+	// aggregate systemd shim counters per scenario name
+	order := []string{"container", "exec", "exec-tty", "container-tty", "status", "scale"}
+	type agg struct{ reactor, getall, ondisk int64 }
+	sums := map[string]*agg{}
+	for i := range r.Scenarios {
+		s := &r.Scenarios[i]
+		if s.Runtime != runtimeSystemd || s.ShimVars == nil {
+			continue
+		}
+		a := sums[s.Scenario]
+		if a == nil {
+			a = &agg{}
+			sums[s.Scenario] = a
+		}
+		a.reactor += s.ShimVars.ReactorHits
+		a.getall += s.ShimVars.GetAllFallbacks
+		a.ondisk += s.ShimVars.OnDiskReads
+	}
+	var cats []string
+	for _, name := range order {
+		if _, ok := sums[name]; ok {
+			cats = append(cats, name)
+		}
+	}
+	if len(cats) == 0 {
+		return ""
+	}
+	reactor := make([]float64, len(cats))
+	getall := make([]float64, len(cats))
+	ondisk := make([]float64, len(cats))
+	for i, name := range cats {
+		a := sums[name]
+		reactor[i] = float64(a.reactor)
+		getall[i] = float64(a.getall)
+		ondisk[i] = float64(a.ondisk)
+	}
+	segs := []stackSeg{
+		{"reactor hit", "var(--cat-1)", reactor},
+		{"GetAll fallback", "var(--cat-6)", getall},
+		{"on-disk read", "var(--cat-4)", ondisk},
+	}
+	return stackedBars("state-source", "events", cats, segs)
+}
+
+// ---- data table --------------------------------------------------------
+
+func writeDataTable(b *strings.Builder, r *Report) {
+	b.WriteString(`<section class="tablewrap"><h2>all measurements</h2>`)
+	b.WriteString(`<p class="sub">Full raw data in <code>results.json</code>, <code>latency.csv</code>, <code>resources.csv</code>.</p>`)
+	b.WriteString(`<table><thead><tr>`)
+	for _, h := range []string{"scenario", "runtime", "variant", "P", "N", "iters", "err", "thrpt/s", "hdln p50", "hdln p99", "cpu/op ms", "reload/op ms", "shim peak", "hit rate"} {
+		fmt.Fprintf(b, `<th>%s</th>`, h)
+	}
+	b.WriteString(`</tr></thead><tbody>`)
+	for i := range r.Scenarios {
+		s := &r.Scenarios[i]
+		op := headlineOp(s.Scenario)
+		hitRate := ""
+		reloadPerOp := ""
+		if s.ShimVars != nil {
+			hitRate = fmt.Sprintf("%.0f%%", s.ShimVars.ReactorHitRate*100)
+			if s.Iterations > 0 {
+				reloadPerOp = fmt.Sprintf("%.1f", s.ShimVars.ReloadTotalMs/float64(s.Iterations))
+			}
+		}
+		cpuPerOp := ""
+		if s.Iterations > 0 {
+			cpuPerOp = fmt.Sprintf("%.1f", s.AttribCPUSeconds/float64(s.Iterations)*1000)
+		}
+		cells := []string{
+			s.Scenario, rtShort(s.Runtime), s.Variant,
+			itoaz(s.Parallel), itoaz(s.ScaleCount),
+			strconv.Itoa(s.Iterations), strconv.Itoa(s.Errors),
+			fmt.Sprintf("%.1f", s.ThroughputOpsPerSec),
+			fmt.Sprintf("%.2f", p50Op(s, op)),
+			fmt.Sprintf("%.2f", p99Op(s, op)),
+			cpuPerOp,
+			reloadPerOp,
+			fmtBytes(shimPeakPss(s)),
+			hitRate,
+		}
+		b.WriteString(`<tr>`)
+		for _, c := range cells {
+			fmt.Fprintf(b, `<td>%s</td>`, html.EscapeString(c))
+		}
+		b.WriteString(`</tr>`)
+	}
+	b.WriteString(`</tbody></table></section>`)
+}
+
+func writeCaveats(b *strings.Builder) {
+	b.WriteString(`<section class="caveats"><h2>reading these numbers</h2><ul>`)
+	for _, c := range []string{
+		"systemd shim = one node-wide daemon (+ systemd supervision, + a PTY helper per TTY workload); runc.v2 = one shim process per container. \"shim cpu\"/\"shim peak\" sum the shim-attributable categories for each design.",
+		"systemd's own CPU is shared with the rest of the system, so its share is approximate over the measurement window.",
+		"Short-lived runc invocations may be undercounted by the sampling interval; both runtimes invoke runc, so this largely cancels in the comparison.",
+		"Inside a VM, absolute latency includes virtualization overhead — treat numbers as relative shim-vs-shim, not absolute host performance.",
+		"State-source counters are a systemd-shim internal diagnostic (runc.v2 has no equivalent), not a head-to-head metric.",
+	} {
+		fmt.Fprintf(b, `<li>%s</li>`, html.EscapeString(c))
+	}
+	b.WriteString(`</ul></section>`)
+}
+
+// ---- small helpers -----------------------------------------------------
+
+func headlineOp(scenario string) string {
+	switch scenario {
+	case "status":
+		return "state"
+	case "scale":
+		return "launch"
+	default:
+		return "total"
+	}
+}
+
+func shimPeakPss(s *ScenarioResult) uint64 {
+	if s.Runtime == runtimeSystemd {
+		return s.MemPeakPss["shim-systemd"] + s.MemPeakPss["tty-helper"]
+	}
+	return s.MemPeakPss["shim-runc"]
+}
+
+func prettyOps(ops []string) []string {
+	m := map[string]string{"exec_create": "exec", "container_new": "new", "container_delete": "cdelete"}
+	out := make([]string, len(ops))
+	for i, o := range ops {
+		if p, ok := m[o]; ok {
+			out[i] = p
+		} else {
+			out[i] = o
+		}
+	}
+	return out
+}
+
+func itoaz(v int) string {
+	if v == 0 {
+		return "-"
+	}
+	return strconv.Itoa(v)
+}
+
+func joinInts(v []int) string {
+	parts := make([]string, len(v))
+	for i, n := range v {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func short(s string, n int) string {
+	if len(s) > n {
+		return s[:n]
+	}
+	return s
+}
+
+func fmtBytes(b uint64) string {
+	switch {
+	case b == 0:
+		return "0"
+	case b >= 1<<30:
+		return fmt.Sprintf("%.1f GiB", float64(b)/(1<<30))
+	case b >= 1<<20:
+		return fmt.Sprintf("%.1f MiB", float64(b)/(1<<20))
+	case b >= 1<<10:
+		return fmt.Sprintf("%.0f KiB", float64(b)/(1<<10))
+	default:
+		return fmt.Sprintf("%d B", b)
+	}
+}

--- a/contrib/bench/main.go
+++ b/contrib/bench/main.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"iter"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+	"runtime/debug"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatalf("bench: %v", err)
+	}
+}
+
+func run() error {
+	var (
+		address     = flag.String("containerd-address", "/run/containerd/containerd.sock", "containerd socket")
+		runtimes    = flag.String("runtimes", runtimeRunc+","+runtimeSystemd, "comma-separated runtime names to compare (runc first, so the systemd node daemon is not resident during runc measurement)")
+		image       = flag.String("image", "docker.io/library/busybox:latest", "OCI image to run")
+		namespace   = flag.String("namespace", "bench", "containerd namespace")
+		iterations  = flag.Int("iterations", 50, "measured lifecycles per latency scenario cell")
+		warmup      = flag.Int("warmup", 5, "warmup lifecycles (discarded) per cell")
+		parallel    = flag.String("parallel", "1,4,8,16", "parallelism degrees for latency scenarios")
+		scaleCounts = flag.String("scale-counts", "1,5,10,25,50", "container counts for the scale scenario")
+		scenarios   = flag.String("scenarios", "container,exec,status,container-tty,exec-tty,scale", "scenarios to run")
+		out         = flag.String("out", "", "output dir (default bench-results/<timestamp>)")
+		shimVarsURL = flag.String("shim-vars-url", "http://127.0.0.1:8089/debug/vars", "systemd shim expvar endpoint (empty to disable)")
+		sampleIval  = flag.Duration("sample-interval", 25*time.Millisecond, "resource sampling interval")
+		statusLoops = flag.Int("status-loops", 500, "State+Stats calls per status scenario cell")
+		scaleHold   = flag.Duration("scale-hold", 3*time.Second, "steady-state hold before sampling stops in the scale scenario")
+	)
+	flag.Parse()
+
+	outDir := *out
+	if outDir == "" {
+		outDir = fmt.Sprintf("bench-results/%s", time.Now().Format("20060102-150405"))
+	}
+
+	cfg := Config{
+		Address:        *address,
+		Runtimes:       slices.Collect(splitCSV(*runtimes)),
+		Image:          *image,
+		Namespace:      *namespace,
+		Iterations:     *iterations,
+		Warmup:         *warmup,
+		Parallel:       slices.Collect(parseIntList(*parallel)),
+		ScaleCounts:    slices.Collect(parseIntList(*scaleCounts)),
+		Scenarios:      slices.Collect(splitCSV(*scenarios)),
+		Out:            outDir,
+		ShimVarsURL:    *shimVarsURL,
+		SampleInterval: *sampleIval,
+		StatusLoops:    *statusLoops,
+		ScaleHold:      *scaleHold,
+	}
+	if len(cfg.Parallel) == 0 {
+		cfg.Parallel = []int{1}
+	}
+
+	// The client is created with WithDefaultNamespace(cfg.Namespace), so its
+	// interceptor supplies the namespace on every call; the context need not
+	// carry it.
+	ctx := context.Background()
+
+	d, err := newDriver(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer d.close()
+
+	d.cleanupNamespace(ctx)
+
+	report := Report{
+		Env:       gatherEnv(ctx, d),
+		StartedAt: time.Now().Format(time.RFC3339),
+		Config:    cfg,
+	}
+
+	for _, rt := range cfg.Runtimes {
+		for _, sc := range cfg.Scenarios {
+			results := d.runScenario(ctx, rt, sc)
+			report.Scenarios = append(report.Scenarios, results...)
+			d.cleanupNamespace(ctx)
+			time.Sleep(time.Second) // let the daemon quiesce between cells
+		}
+	}
+
+	if err := writeOutputs(cfg, &report); err != nil {
+		return err
+	}
+	fmt.Printf("\nWrote results to %s\n  report: %s\n", cfg.Out, cfg.Out+"/report.html")
+	return nil
+}
+
+// runScenario expands one scenario name into its parallelism/scale cells for a
+// runtime and returns the results. Errors are logged and the cell skipped so a
+// single failure does not abort the whole run.
+func (d *driver) runScenario(ctx context.Context, rt, sc string) []ScenarioResult {
+	var results []ScenarioResult
+	log.Printf("[%s] scenario %s", rt, sc)
+
+	switch sc {
+	case "container":
+		for _, p := range d.cfg.Parallel {
+			results = append(results, d.scenarioContainer(ctx, rt, false, p))
+		}
+	case "container-tty":
+		for _, p := range d.cfg.Parallel {
+			results = append(results, d.scenarioContainer(ctx, rt, true, p))
+		}
+	case "exec", "exec-tty":
+		tty := sc == "exec-tty"
+		for _, p := range d.cfg.Parallel {
+			if r, err := d.scenarioExec(ctx, rt, tty, p, false); err != nil {
+				log.Printf("  %s p=%d spread: %v", sc, p, err)
+			} else {
+				results = append(results, r)
+			}
+			if p > 1 {
+				if r, err := d.scenarioExec(ctx, rt, tty, p, true); err != nil {
+					log.Printf("  %s p=%d single: %v", sc, p, err)
+				} else {
+					results = append(results, r)
+				}
+			}
+		}
+	case "status":
+		for _, p := range d.cfg.Parallel {
+			if r, err := d.scenarioStatus(ctx, rt, p); err != nil {
+				log.Printf("  status p=%d: %v", p, err)
+			} else {
+				results = append(results, r)
+			}
+		}
+	case "scale":
+		for _, n := range d.cfg.ScaleCounts {
+			if r, err := d.scenarioScale(ctx, rt, n); err != nil {
+				log.Printf("  scale n=%d: %v", n, err)
+			} else {
+				results = append(results, r)
+			}
+		}
+	default:
+		log.Printf("  unknown scenario %q, skipping", sc)
+	}
+	return results
+}
+
+// cleanupNamespace removes any leftover containers/tasks in the bench namespace
+// (from this run's teardown races or a prior aborted run).
+func (d *driver) cleanupNamespace(ctx context.Context) {
+	cs, err := d.client.Containers(ctx)
+	if err != nil {
+		return
+	}
+	for _, c := range cs {
+		// Only touch containers this harness created; never delete unrelated
+		// workloads that happen to share the namespace.
+		if !strings.HasPrefix(c.ID(), benchIDPrefix) {
+			continue
+		}
+		if t, err := c.Task(ctx, nil); err == nil {
+			waitCh, _ := t.Wait(ctx)
+			t.Kill(ctx, 9)
+			if waitCh != nil {
+				select {
+				case <-waitCh:
+				case <-time.After(5 * time.Second):
+				}
+			}
+			t.Delete(ctx)
+		}
+		c.Delete(ctx, containerd.WithSnapshotCleanup)
+	}
+}
+
+func gatherEnv(ctx context.Context, d *driver) Env {
+	e := Env{
+		Arch:          runtime.GOARCH,
+		NumCPU:        runtime.NumCPU(),
+		GoVersion:     runtime.Version(),
+		ClockTicksHz:  int(userHZ),
+		Kernel:        strings.TrimSpace(readFile("/proc/sys/kernel/osrelease")),
+		MemTotalBytes: readMemTotal(),
+		CgroupVersion: cgroupVersion(),
+		RuncVersion:   commandFirstLine("runc", "--version"),
+		InsideVM:      detectVM(),
+	}
+	e.Hostname, _ = os.Hostname()
+	if v, err := d.client.Version(ctx); err == nil {
+		e.ContainerdVer = v.Version
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		for _, s := range bi.Settings {
+			if s.Key == "vcs.revision" {
+				e.HarnessGitCommit = s.Value
+			}
+		}
+	}
+	return e
+}
+
+func splitCSV(s string) iter.Seq[string] {
+	return func(yield func(string) bool) {
+		for p := range strings.SplitSeq(s, ",") {
+			p = strings.TrimSpace(p)
+			if p == "" {
+				continue
+			}
+			if !yield(p) {
+				return
+			}
+		}
+	}
+}
+
+func parseIntList(s string) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		for p := range splitCSV(s) {
+			if n, err := strconv.Atoi(p); err == nil && n > 0 {
+				if !yield(n) {
+					return
+				}
+			}
+		}
+	}
+}
+
+func readFile(path string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
+func readMemTotal() uint64 {
+	for line := range strings.SplitSeq(readFile("/proc/meminfo"), "\n") {
+		if strings.HasPrefix(line, "MemTotal:") {
+			return parseKBLine(line) * 1024
+		}
+	}
+	return 0
+}
+
+func cgroupVersion() string {
+	if _, err := os.Stat("/sys/fs/cgroup/cgroup.controllers"); err == nil {
+		return "v2"
+	}
+	return "v1"
+}
+
+func commandFirstLine(name string, args ...string) string {
+	path, err := exec.LookPath(name)
+	if err != nil {
+		return ""
+	}
+	out, err := exec.Command(path, args...).Output()
+	if err != nil {
+		return ""
+	}
+	if i := strings.IndexByte(string(out), '\n'); i >= 0 {
+		return strings.TrimSpace(string(out)[:i])
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func detectVM() bool {
+	if path, err := exec.LookPath("systemd-detect-virt"); err == nil {
+		out, _ := exec.Command(path, "--vm").Output()
+		v := strings.TrimSpace(string(out))
+		return v != "" && v != "none"
+	}
+	return false
+}

--- a/contrib/bench/report.go
+++ b/contrib/bench/report.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strconv"
+)
+
+func writeOutputs(cfg Config, r *Report) error {
+	if err := os.MkdirAll(cfg.Out, 0o755); err != nil {
+		return err
+	}
+	if err := writeJSON(filepath.Join(cfg.Out, "results.json"), r); err != nil {
+		return err
+	}
+	if err := writeJSON(filepath.Join(cfg.Out, "env.json"), r.Env); err != nil {
+		return err
+	}
+	if err := writeLatencyCSV(filepath.Join(cfg.Out, "latency.csv"), r); err != nil {
+		return err
+	}
+	if err := writeResourceCSV(filepath.Join(cfg.Out, "resources.csv"), r); err != nil {
+		return err
+	}
+	return writeHTML(filepath.Join(cfg.Out, "report.html"), r)
+}
+
+func writeJSON(path string, v any) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	enc := json.NewEncoder(f)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func writeLatencyCSV(path string, r *Report) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	w.Write([]string{"scenario", "runtime", "variant", "parallel", "scale_count", "op",
+		"count", "min_ms", "p50_ms", "p90_ms", "p99_ms", "max_ms", "mean_ms", "stddev_ms"})
+	for _, s := range r.Scenarios {
+		for op, st := range s.Ops {
+			w.Write([]string{s.Scenario, s.Runtime, s.Variant,
+				strconv.Itoa(s.Parallel), strconv.Itoa(s.ScaleCount), op,
+				strconv.Itoa(st.Count),
+				f2(st.Min), f2(st.P50), f2(st.P90), f2(st.P99), f2(st.Max), f2(st.Mean), f2(st.Stddev)})
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func writeResourceCSV(path string, r *Report) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+
+	header := []string{"scenario", "runtime", "variant", "parallel", "scale_count",
+		"iterations", "errors", "wall_s", "throughput_ops_s",
+		"system_cpu_s", "harness_cpu_s", "attrib_cpu_s", "system_util_pct", "shim_cgroup_cpu_s"}
+	for _, c := range sampledCategories {
+		header = append(header, "cpu_s_"+string(c))
+	}
+	for _, c := range sampledCategories {
+		header = append(header, "peak_pss_"+string(c))
+	}
+	header = append(header, "reactor_hits", "getall_fallbacks", "ondisk_reads", "reactor_hit_rate",
+		"daemon_reload_count", "daemon_reload_total_ms", "daemon_reload_mean_ms", "shim_go_heap_bytes")
+	w.Write(header)
+
+	for _, s := range r.Scenarios {
+		row := []string{s.Scenario, s.Runtime, s.Variant,
+			strconv.Itoa(s.Parallel), strconv.Itoa(s.ScaleCount),
+			strconv.Itoa(s.Iterations), strconv.Itoa(s.Errors),
+			f2(s.WallSeconds), f2(s.ThroughputOpsPerSec),
+			f2(s.SystemCPUSeconds), f2(s.HarnessCPUSeconds), f2(s.AttribCPUSeconds),
+			f2(s.SystemUtilPct), f2(s.ShimCgroupCPUSecond)}
+		for _, c := range sampledCategories {
+			row = append(row, f2(s.CPUSeconds[string(c)]))
+		}
+		for _, c := range sampledCategories {
+			row = append(row, strconv.FormatUint(s.MemPeakPss[string(c)], 10))
+		}
+		if s.ShimVars != nil {
+			row = append(row, strconv.FormatInt(s.ShimVars.ReactorHits, 10),
+				strconv.FormatInt(s.ShimVars.GetAllFallbacks, 10),
+				strconv.FormatInt(s.ShimVars.OnDiskReads, 10),
+				f2(s.ShimVars.ReactorHitRate),
+				strconv.FormatInt(s.ShimVars.ReloadCount, 10),
+				f2(s.ShimVars.ReloadTotalMs),
+				f2(s.ShimVars.ReloadMeanMs))
+		} else {
+			row = append(row, "", "", "", "", "", "", "")
+		}
+		row = append(row, strconv.FormatUint(s.ShimGoHeapBytes, 10))
+		w.Write(row)
+	}
+	w.Flush()
+	return w.Error()
+}
+
+func f2(v float64) string { return strconv.FormatFloat(v, 'f', 3, 64) }
+
+// ---- lookups over the results -----------------------------------------
+
+func (r *Report) find(scenario, runtime, variant string, parallel, scale int) *ScenarioResult {
+	for i := range r.Scenarios {
+		s := &r.Scenarios[i]
+		if s.Scenario == scenario && s.Runtime == runtime && s.Variant == variant &&
+			s.Parallel == parallel && s.ScaleCount == scale {
+			return s
+		}
+	}
+	return nil
+}
+
+func (r *Report) runtimesPresent() []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, rt := range r.Config.Runtimes {
+		if !seen[rt] {
+			for _, s := range r.Scenarios {
+				if s.Runtime == rt {
+					out = append(out, rt)
+					seen[rt] = true
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+func rtColor(rt string) string {
+	switch rt {
+	case runtimeSystemd:
+		return "var(--rt-systemd)"
+	case runtimeRunc:
+		return "var(--rt-runc)"
+	default:
+		return "var(--cat-3)"
+	}
+}
+
+func rtShort(rt string) string {
+	switch rt {
+	case runtimeSystemd:
+		return "systemd"
+	case runtimeRunc:
+		return "runc.v2"
+	default:
+		return rt
+	}
+}
+
+func p50Op(s *ScenarioResult, op string) float64 {
+	if s == nil {
+		return 0
+	}
+	return s.Ops[op].P50
+}
+
+func p99Op(s *ScenarioResult, op string) float64 {
+	if s == nil {
+		return 0
+	}
+	return s.Ops[op].P99
+}

--- a/contrib/bench/report_test.go
+++ b/contrib/bench/report_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestReportOutputs(t *testing.T) {
+	// given: a synthetic run with both runtimes across latency, tty, status,
+	// and scale scenarios, with resource and state-source data populated.
+	r := syntheticReport()
+	dir := t.TempDir()
+	cfg := r.Config
+	cfg.Out = dir
+
+	// when: the outputs are written.
+	if err := writeOutputs(cfg, &r); err != nil {
+		t.Fatalf("writeOutputs: %v", err)
+	}
+
+	t.Run("all artifacts are written", func(t *testing.T) {
+		for _, name := range []string{"results.json", "env.json", "latency.csv", "resources.csv", "report.html"} {
+			if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+				t.Errorf("missing %s: %v", name, err)
+			}
+		}
+	})
+
+	htmlBytes, err := os.ReadFile(filepath.Join(dir, "report.html"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(htmlBytes)
+
+	// Optionally dump the artifact for manual inspection.
+	if out := os.Getenv("BENCH_DUMP"); out != "" {
+		os.WriteFile(out, htmlBytes, 0o644)
+	}
+
+	t.Run("html has no unfilled format directives", func(t *testing.T) {
+		if strings.Contains(doc, "%!") {
+			t.Errorf("report.html contains a Go format error (%%!)")
+		}
+	})
+
+	t.Run("every svg element is closed", func(t *testing.T) {
+		if o, c := strings.Count(doc, "<svg"), strings.Count(doc, "</svg>"); o != c {
+			t.Errorf("unbalanced svg tags: %d open, %d close", o, c)
+		}
+		if o, c := strings.Count(doc, "<path"), strings.Count(doc, "</path>")+strings.Count(doc, "/>"); o > c {
+			t.Errorf("suspiciously many unclosed path tags: %d open", o)
+		}
+	})
+
+	t.Run("charts and palette are present", func(t *testing.T) {
+		for _, marker := range []string{"--rt-systemd", "--cat-1", "class=\"chart\"", "systemd", "runc.v2"} {
+			if !strings.Contains(doc, marker) {
+				t.Errorf("report.html missing marker %q", marker)
+			}
+		}
+		if n := strings.Count(doc, "<svg"); n < 5 {
+			t.Errorf("expected several charts, found %d svg elements", n)
+		}
+	})
+
+	t.Run("no NaN or Inf leaked into svg coordinates", func(t *testing.T) {
+		for _, bad := range []string{"NaN", "+Inf", "-Inf"} {
+			if strings.Contains(doc, bad) {
+				t.Errorf("report.html contains %q", bad)
+			}
+		}
+	})
+
+	t.Run("csv rows are emitted for measurements", func(t *testing.T) {
+		lat, _ := os.ReadFile(filepath.Join(dir, "latency.csv"))
+		if lines := strings.Count(string(lat), "\n"); lines < 5 {
+			t.Errorf("latency.csv looks empty: %d lines", lines)
+		}
+		res, _ := os.ReadFile(filepath.Join(dir, "resources.csv"))
+		if !strings.Contains(string(res), "reactor_hit_rate") {
+			t.Errorf("resources.csv missing expected header")
+		}
+	})
+}
+
+// syntheticReport builds a deterministic Report covering the chart code paths.
+func syntheticReport() Report {
+	cfg := Config{
+		Runtimes:    []string{runtimeSystemd, runtimeRunc},
+		Image:       "docker.io/library/busybox:latest",
+		Iterations:  50,
+		Warmup:      5,
+		Parallel:    []int{1, 4},
+		ScaleCounts: []int{1, 5},
+	}
+	r := Report{
+		Env: Env{
+			Hostname: "test", Kernel: "7.1.4", Arch: "amd64", NumCPU: 8,
+			MemTotalBytes: 16 << 30, CgroupVersion: "v2", GoVersion: "go1.26",
+			ContainerdVer: "2.3.3", RuncVersion: "runc 1.2", InsideVM: true,
+		},
+		StartedAt: "2026-07-22T12:00:00Z",
+		Config:    cfg,
+	}
+
+	mkOps := func(names []string, base float64) map[string]OpStats {
+		m := map[string]OpStats{}
+		for i, n := range names {
+			v := base + float64(i)*2
+			m[n] = OpStats{Count: 50, Min: v * 0.8, P50: v, P90: v * 1.4, P99: v * 2, Max: v * 3, Mean: v * 1.1, Stddev: v * 0.2}
+		}
+		return m
+	}
+	cpu := func(shim, runcS float64) map[string]float64 {
+		return map[string]float64{"shim-systemd": shim, "tty-helper": 0, "shim-runc": runcS, "runc": 1.2, "systemd": 0.3, "containerd": 0.5}
+	}
+	mem := func(shim uint64) map[string]uint64 {
+		return map[string]uint64{"shim-systemd": shim, "tty-helper": 0, "shim-runc": shim, "runc": 4 << 20, "systemd": 20 << 20, "containerd": 30 << 20}
+	}
+	vars := func(hit, getall, ondisk int64) *ShimVarsDelta {
+		d := &ShimVarsDelta{ReactorHits: hit, GetAllFallbacks: getall, OnDiskReads: ondisk,
+			ReloadCount: 40, ReloadTotalMs: 400, ReloadMeanMs: 10}
+		if hit+getall > 0 {
+			d.ReactorHitRate = float64(hit) / float64(hit+getall)
+		}
+		return d
+	}
+
+	add := func(s ScenarioResult) { r.Scenarios = append(r.Scenarios, s) }
+
+	for ri, rt := range cfg.Runtimes {
+		sysd := rt == runtimeSystemd
+		base := 20.0 + float64(ri)*5
+		for _, p := range cfg.Parallel {
+			c := ScenarioResult{
+				Scenario: "container", Runtime: rt, Parallel: p, Iterations: 50,
+				ThroughputOpsPerSec: 30 - float64(ri*5) - float64(p), WallSeconds: 2,
+				Ops:        mkOps([]string{"create", "start", "run", "delete", "total"}, base+float64(p)),
+				CPUSeconds: cpu(1.5, 2.0), MemPeakPss: mem(uint64(40+ri*10) << 20),
+				SystemCPUSeconds: 8 - float64(ri)*3, HarnessCPUSeconds: 1.5,
+				AttribCPUSeconds: 6.5 - float64(ri)*3, SystemUtilPct: 40 - float64(ri)*10,
+			}
+			if sysd {
+				c.ShimVars = vars(int64(90+p), int64(10), int64(2))
+				c.ShimGoHeapBytes = 12 << 20
+			}
+			add(c)
+
+			e := ScenarioResult{
+				Scenario: "exec", Runtime: rt, Variant: "spread", Parallel: p, Iterations: 50,
+				ThroughputOpsPerSec: 40 - float64(p), WallSeconds: 1.5,
+				Ops:        mkOps([]string{"exec_create", "start", "run", "delete", "total"}, base*0.6),
+				CPUSeconds: cpu(0.8, 1.1), MemPeakPss: mem(uint64(38+ri*8) << 20),
+			}
+			if sysd {
+				e.ShimVars = vars(int64(80), int64(5), int64(1))
+			}
+			add(e)
+
+			if p > 1 {
+				es := e
+				es.Variant = "single-container"
+				es.Ops = mkOps([]string{"exec_create", "start", "run", "delete", "total"}, base*0.6+float64(p)*3)
+				add(es)
+			}
+		}
+
+		st := ScenarioResult{
+			Scenario: "status", Runtime: rt, Parallel: 1, Iterations: 500,
+			Ops: mkOps([]string{"state", "stats"}, 1.5), CPUSeconds: cpu(0.2, 0.3), MemPeakPss: mem(uint64(35+ri*8) << 20),
+		}
+		add(st)
+
+		ct := ScenarioResult{
+			Scenario: "container-tty", Runtime: rt, Parallel: 1, Iterations: 50,
+			Ops: mkOps([]string{"create", "start", "run", "delete", "total"}, base*1.3), CPUSeconds: cpu(1.8, 2.1), MemPeakPss: mem(uint64(45+ri*10) << 20),
+		}
+		add(ct)
+		et := ScenarioResult{
+			Scenario: "exec-tty", Runtime: rt, Variant: "spread", Parallel: 1, Iterations: 50,
+			Ops: mkOps([]string{"exec_create", "start", "run", "delete", "total"}, base*0.8), CPUSeconds: cpu(1.0, 1.3), MemPeakPss: mem(uint64(42+ri*9) << 20),
+		}
+		add(et)
+
+		for _, n := range cfg.ScaleCounts {
+			sc := ScenarioResult{
+				Scenario: "scale", Runtime: rt, ScaleCount: n, Iterations: n,
+				ThroughputOpsPerSec: 15 - float64(ri*3), WallSeconds: float64(n) * 0.1,
+				Ops:        map[string]OpStats{"launch": {Count: n, P50: 60 + base, P99: 120}},
+				CPUSeconds: cpu(float64(n)*0.1, float64(n)*0.2),
+				MemPeakPss: mem(uint64((30+ri*5)+n*(2+ri*3)) << 20),
+			}
+			if sysd {
+				sc.ShimVars = vars(int64(n*2), int64(1), 0)
+			}
+			add(sc)
+		}
+	}
+	return r
+}

--- a/contrib/bench/sample.go
+++ b/contrib/bench/sample.go
@@ -1,0 +1,416 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// userHZ is Linux USER_HZ (CLK_TCK). It is 100 on effectively all Linux
+// configurations; /proc/<pid>/stat CPU fields are counted in these ticks.
+const userHZ = 100.0
+
+type category string
+
+const (
+	catShimSystemd category = "shim-systemd"
+	catTTYHelper   category = "tty-helper"
+	catShimRunc    category = "shim-runc"
+	catRunc        category = "runc"
+	catSystemd     category = "systemd"
+	catContainerd  category = "containerd"
+	catOther       category = ""
+)
+
+// sampledCategories is the fixed set reported for every scenario so charts and
+// CSVs have a stable schema.
+var sampledCategories = []category{
+	catShimSystemd, catTTYHelper, catShimRunc, catRunc, catSystemd, catContainerd,
+}
+
+// sampler periodically walks /proc to attribute CPU and Pss to process
+// categories over a measurement window. CPU is accounted exactly for
+// long-lived processes (the shim daemon, containerd) and approximately for
+// short-lived ones (runc invocations may be undercounted at coarse intervals);
+// see the plan's fairness caveats.
+type sampler struct {
+	interval    time.Duration
+	seriesEvery time.Duration
+
+	stop chan struct{}
+	done chan struct{}
+
+	startWall time.Time
+
+	// baseline holds cumulative CPU-seconds at first observation for pids that
+	// already existed when sampling started; their window contribution is
+	// (current - baseline). Pids first seen later were born during the window,
+	// so their full cumulative counts.
+	baseline map[int]float64
+	contrib  map[int]float64
+	catOf    map[int]category
+
+	pssTotals map[category][]uint64
+
+	series       []SamplePoint
+	lastSeries   time.Time
+	lastContrib  map[category]float64
+	lastSeriesOK bool
+
+	// Window-level, lifetime-independent CPU accounting (start/end deltas), so
+	// short-lived processes (runc, per-container shims) are not undercounted the
+	// way high-frequency per-process sampling undercounts them.
+	sysBusyStart  float64 // /proc/stat busy jiffies
+	sysTotalStart float64 // /proc/stat total jiffies
+	selfStart     float64 // this process (driver + sampler) CPU seconds
+	shimCgStart   int64   // systemd shim daemon cgroup usage_usec (-1 if n/a)
+}
+
+// shimCgroupCPUStat is the systemd shim daemon's cgroup v2 cpu accounting file
+// (it runs as a system service). Used for an exact cross-check of the daemon's
+// CPU independent of sampling.
+const shimCgroupCPUStat = "/sys/fs/cgroup/system.slice/containerd-shim-systemd-v1.service/cpu.stat"
+
+func newSampler(interval time.Duration) *sampler {
+	if interval <= 0 {
+		interval = 25 * time.Millisecond
+	}
+	return &sampler{
+		interval:    interval,
+		seriesEvery: max(5*interval, 200*time.Millisecond),
+		stop:        make(chan struct{}),
+		done:        make(chan struct{}),
+		baseline:    map[int]float64{},
+		contrib:     map[int]float64{},
+		catOf:       map[int]category{},
+		pssTotals:   map[category][]uint64{},
+		lastContrib: map[category]float64{},
+	}
+}
+
+func (s *sampler) start() {
+	s.startWall = time.Now()
+	s.sysBusyStart, s.sysTotalStart = readSystemCPU()
+	s.selfStart = readSelfCPU()
+	s.shimCgStart = readCgroupUsageUsec(shimCgroupCPUStat)
+	// Establish the per-process CPU baseline synchronously, before the caller
+	// launches any workload, so a process born right after start() is not
+	// mistaken for pre-existing (which would subtract its startup CPU).
+	s.sampleOnce(true)
+	go s.run()
+}
+
+func (s *sampler) run() {
+	defer close(s.done)
+	t := time.NewTicker(s.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-s.stop:
+			s.sampleOnce(false)
+			return
+		case <-t.C:
+			s.sampleOnce(false)
+		}
+	}
+}
+
+// stopAndCollect stops sampling and returns the aggregated result.
+func (s *sampler) stopAndCollect() sampleResult {
+	close(s.stop)
+	<-s.done
+
+	busyEnd, totalEnd := readSystemCPU()
+	selfEnd := readSelfCPU()
+	shimCgEnd := readCgroupUsageUsec(shimCgroupCPUStat)
+
+	res := s.collect()
+	res.sysBusySeconds = (busyEnd - s.sysBusyStart) / userHZ
+	res.sysTotalSeconds = (totalEnd - s.sysTotalStart) / userHZ
+	res.harnessSeconds = (selfEnd - s.selfStart) / userHZ
+	res.shimCgroupSeconds = -1
+	if s.shimCgStart >= 0 && shimCgEnd >= 0 {
+		res.shimCgroupSeconds = float64(shimCgEnd-s.shimCgStart) / 1e6
+	}
+	return res
+}
+
+type sampleResult struct {
+	cpuSeconds map[category]float64
+	peakPss    map[category]uint64
+	meanPss    map[category]uint64
+	series     []SamplePoint
+	wall       float64
+
+	sysBusySeconds    float64 // system-wide busy CPU-seconds over the window
+	sysTotalSeconds   float64 // system-wide total CPU-seconds (busy+idle), all cores
+	harnessSeconds    float64 // this process's CPU (driver + sampler) — subtract for server-side
+	shimCgroupSeconds float64 // systemd shim daemon cgroup CPU (-1 if unavailable)
+}
+
+func (s *sampler) collect() sampleResult {
+	res := sampleResult{
+		cpuSeconds: map[category]float64{},
+		peakPss:    map[category]uint64{},
+		meanPss:    map[category]uint64{},
+		series:     s.series,
+		wall:       time.Since(s.startWall).Seconds(),
+	}
+	for pid, c := range s.catOf {
+		res.cpuSeconds[c] += s.contrib[pid]
+	}
+	for _, c := range sampledCategories {
+		vals := s.pssTotals[c]
+		if len(vals) == 0 {
+			continue
+		}
+		var sum, peak uint64
+		for _, v := range vals {
+			sum += v
+			peak = max(peak, v)
+		}
+		res.peakPss[c] = peak
+		res.meanPss[c] = sum / uint64(len(vals))
+	}
+	return res
+}
+
+func (s *sampler) sampleOnce(baselinePass bool) {
+	now := time.Now()
+	perCatPss := map[category]uint64{}
+
+	pids, err := os.ReadDir("/proc")
+	if err != nil {
+		return
+	}
+	for _, ent := range pids {
+		if !ent.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(ent.Name())
+		if err != nil {
+			continue
+		}
+		argv := readCmdline(pid)
+		comm, cpuTicks, ok := readStat(pid)
+		if !ok {
+			continue
+		}
+		cat := categorize(pid, argv, comm)
+		if cat == catOther {
+			continue
+		}
+		cpuCum := cpuTicks / userHZ
+
+		if baselinePass {
+			s.baseline[pid] = cpuCum
+			s.contrib[pid] = 0
+		} else if b, existed := s.baseline[pid]; existed {
+			if d := cpuCum - b; d >= 0 {
+				s.contrib[pid] = d
+			}
+		} else {
+			s.contrib[pid] = cpuCum
+		}
+		s.catOf[pid] = cat
+
+		perCatPss[cat] += readPss(pid)
+	}
+
+	for _, c := range sampledCategories {
+		s.pssTotals[c] = append(s.pssTotals[c], perCatPss[c])
+	}
+
+	if baselinePass {
+		s.lastSeries = now
+		return
+	}
+	if now.Sub(s.lastSeries) < s.seriesEvery {
+		return
+	}
+	s.emitSeries(now, perCatPss)
+}
+
+func (s *sampler) emitSeries(now time.Time, perCatPss map[category]uint64) {
+	nowContrib := map[category]float64{}
+	for pid, c := range s.catOf {
+		nowContrib[c] += s.contrib[pid]
+	}
+	pt := SamplePoint{
+		TSeconds: now.Sub(s.startWall).Seconds(),
+		PssBytes: map[string]uint64{},
+		CPUPct:   map[string]float64{},
+	}
+	elapsed := now.Sub(s.lastSeries).Seconds()
+	for _, c := range sampledCategories {
+		pt.PssBytes[string(c)] = perCatPss[c]
+		if s.lastSeriesOK && elapsed > 0 {
+			pt.CPUPct[string(c)] = (nowContrib[c] - s.lastContrib[c]) / elapsed * 100
+		}
+	}
+	s.series = append(s.series, pt)
+	s.lastContrib = nowContrib
+	s.lastSeries = now
+	s.lastSeriesOK = true
+}
+
+// categorize maps a process to a benchmark category using its argv (comm is
+// truncated to 15 chars, so both shims share the comm "containerd-shim" and
+// cannot be told apart without the full command line).
+func categorize(pid int, argv []string, comm string) category {
+	base := comm
+	if len(argv) > 0 && argv[0] != "" {
+		base = filepath.Base(argv[0])
+	}
+	switch base {
+	case "containerd-shim-systemd-v1":
+		if slices.Contains(argv, "tty-handshake") {
+			return catTTYHelper
+		}
+		return catShimSystemd
+	case "containerd-shim-runc-v2":
+		return catShimRunc
+	case "runc":
+		return catRunc
+	case "containerd":
+		return catContainerd
+	case "systemd":
+		return catSystemd
+	}
+	if pid == 1 {
+		return catSystemd
+	}
+	return catOther
+}
+
+func readCmdline(pid int) []string {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/cmdline")
+	if err != nil || len(data) == 0 {
+		return nil
+	}
+	parts := strings.Split(strings.TrimRight(string(data), "\x00"), "\x00")
+	return parts
+}
+
+// readStat returns the process comm and cumulative (utime+stime) in ticks.
+func readStat(pid int) (comm string, cpuTicks float64, ok bool) {
+	data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/stat")
+	if err != nil {
+		return "", 0, false
+	}
+	s := string(data)
+	// comm is wrapped in parens and may itself contain spaces/parens; split on
+	// the final ')' so the numeric fields after it parse cleanly.
+	lp := strings.IndexByte(s, '(')
+	rp := strings.LastIndexByte(s, ')')
+	if lp < 0 || rp < 0 || rp < lp {
+		return "", 0, false
+	}
+	comm = s[lp+1 : rp]
+	rest := strings.Fields(s[rp+1:])
+	// rest[0]=state, so utime (field 14) is rest[11] and stime (field 15) rest[12].
+	if len(rest) < 13 {
+		return comm, 0, false
+	}
+	utime, err1 := strconv.ParseFloat(rest[11], 64)
+	stime, err2 := strconv.ParseFloat(rest[12], 64)
+	if err1 != nil || err2 != nil {
+		return comm, 0, false
+	}
+	return comm, utime + stime, true
+}
+
+// readPss returns the process proportional set size in bytes, preferring
+// smaps_rollup (accounts for shared pages) and falling back to VmRSS.
+func readPss(pid int) uint64 {
+	if data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/smaps_rollup"); err == nil {
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if strings.HasPrefix(line, "Pss:") {
+				return parseKBLine(line) * 1024
+			}
+		}
+	}
+	if data, err := os.ReadFile("/proc/" + strconv.Itoa(pid) + "/status"); err == nil {
+		for line := range strings.SplitSeq(string(data), "\n") {
+			if strings.HasPrefix(line, "VmRSS:") {
+				return parseKBLine(line) * 1024
+			}
+		}
+	}
+	return 0
+}
+
+func parseKBLine(line string) uint64 {
+	fields := strings.Fields(line)
+	if len(fields) < 2 {
+		return 0
+	}
+	v, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// readSystemCPU returns aggregate busy and total CPU jiffies from /proc/stat's
+// "cpu" line. Busy excludes idle+iowait. This captures all CPU regardless of
+// process lifetime, so short-lived runc/shim processes are counted.
+func readSystemCPU() (busy, total float64) {
+	data, err := os.ReadFile("/proc/stat")
+	if err != nil {
+		return 0, 0
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if !strings.HasPrefix(line, "cpu ") {
+			continue
+		}
+		fields := strings.Fields(line)[1:]
+		var idle float64
+		for i, f := range fields {
+			v, err := strconv.ParseFloat(f, 64)
+			if err != nil {
+				continue
+			}
+			total += v
+			if i == 3 || i == 4 { // idle, iowait
+				idle += v
+			}
+		}
+		busy = total - idle
+		return busy, total
+	}
+	return 0, 0
+}
+
+// readSelfCPU returns this process's cumulative CPU in ticks (driver +
+// sampler). Callers divide by userHZ to get seconds, consistent with
+// readSystemCPU.
+func readSelfCPU() float64 {
+	_, ticks, ok := readStat(os.Getpid())
+	if !ok {
+		return 0
+	}
+	return ticks
+}
+
+// readCgroupUsageUsec reads usage_usec from a cgroup v2 cpu.stat file, or -1.
+func readCgroupUsageUsec(path string) int64 {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return -1
+	}
+	for line := range strings.SplitSeq(string(data), "\n") {
+		if strings.HasPrefix(line, "usage_usec") {
+			fields := strings.Fields(line)
+			if len(fields) >= 2 {
+				if v, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+					return v
+				}
+			}
+		}
+	}
+	return -1
+}

--- a/contrib/bench/scenarios.go
+++ b/contrib/bench/scenarios.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"context"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	containerd "github.com/containerd/containerd/v2/client"
+)
+
+const statusPoolSize = 10
+
+// measuredOut bundles everything captured while running a measured op batch.
+type measuredOut struct {
+	raw    map[string][]float64
+	errs   int
+	wall   time.Duration
+	count  int
+	sample sampleResult
+	vars   *ShimVarsDelta
+	goHeap uint64
+}
+
+// measure runs warmup (discarded) then `total` measured invocations of opFn at
+// the given parallelism, wrapping the measured region with resource sampling
+// and (for the systemd shim) a before/after scrape of the expvar counters.
+func (d *driver) measure(ctx context.Context, rt string, total, parallel int, opFn func() (map[string]float64, error)) measuredOut {
+	if d.cfg.Warmup > 0 {
+		runConcurrentN(d.cfg.Warmup, parallel, opFn)
+	}
+
+	scrape := rt == runtimeSystemd && d.cfg.ShimVarsURL != ""
+	var before *ShimVarsSnapshot
+	if scrape {
+		before, _ = scrapeShimVars(ctx, d.cfg.ShimVarsURL)
+	}
+
+	smp := newSampler(d.cfg.SampleInterval)
+	smp.start()
+	raw, errs, wall := runConcurrentN(total, parallel, opFn)
+	sres := smp.stopAndCollect()
+
+	out := measuredOut{raw: raw, errs: errs, wall: wall, count: total, sample: sres}
+	if scrape {
+		after, _ := scrapeShimVars(ctx, d.cfg.ShimVarsURL)
+		out.vars = diffShimVars(before, after)
+		if after != nil {
+			out.goHeap = after.GoHeapAlloc
+		}
+	}
+	return out
+}
+
+func buildResult(scenario, rt, variant string, parallel int, m measuredOut) ScenarioResult {
+	r := ScenarioResult{
+		Scenario:        scenario,
+		Runtime:         rt,
+		Variant:         variant,
+		Parallel:        parallel,
+		Iterations:      m.count,
+		Errors:          m.errs,
+		WallSeconds:     m.wall.Seconds(),
+		Ops:             map[string]OpStats{},
+		CPUSeconds:      convertCatMapToStringMap(m.sample.cpuSeconds),
+		MemPeakPss:      convertCatMapToStringMap(m.sample.peakPss),
+		MemMeanPss:      convertCatMapToStringMap(m.sample.meanPss),
+		Series:          m.sample.series,
+		ShimVars:        m.vars,
+		ShimGoHeapBytes: m.goHeap,
+	}
+	r.SystemCPUSeconds = m.sample.sysBusySeconds
+	r.HarnessCPUSeconds = m.sample.harnessSeconds
+	r.AttribCPUSeconds = m.sample.sysBusySeconds - m.sample.harnessSeconds
+	if r.AttribCPUSeconds < 0 {
+		r.AttribCPUSeconds = 0
+	}
+	if m.sample.sysTotalSeconds > 0 {
+		r.SystemUtilPct = m.sample.sysBusySeconds / m.sample.sysTotalSeconds * 100
+	}
+	r.ShimCgroupCPUSecond = m.sample.shimCgroupSeconds
+	for k, v := range m.raw {
+		r.Ops[k] = summarize(v, true)
+	}
+	if m.wall > 0 {
+		r.ThroughputOpsPerSec = float64(m.count-m.errs) / m.wall.Seconds()
+	}
+	return r
+}
+
+// scenarioContainer times full container lifecycles at a parallelism degree.
+func (d *driver) scenarioContainer(ctx context.Context, rt string, tty bool, parallel int) ScenarioResult {
+	opFn := func() (map[string]float64, error) { return d.containerLifecycle(ctx, rt, tty) }
+	m := d.measure(ctx, rt, d.cfg.Iterations, parallel, opFn)
+	name := "container"
+	if tty {
+		name = "container-tty"
+	}
+	return buildResult(name, rt, "", parallel, m)
+}
+
+// scenarioExec times short execs against running containers. With single=true
+// all execs target one container (worst case for the shared per-container
+// lock); otherwise they spread across `parallel` containers.
+func (d *driver) scenarioExec(ctx context.Context, rt string, tty bool, parallel int, single bool) (ScenarioResult, error) {
+	nContainers := parallel
+	variant := "spread"
+	if single {
+		nContainers = 1
+		variant = "single-container"
+	}
+	if nContainers < 1 {
+		nContainers = 1
+	}
+
+	tasks, teardown, err := d.taskPool(ctx, rt, "execbase", nContainers)
+	if err != nil {
+		return ScenarioResult{}, err
+	}
+	defer teardown()
+
+	var rr atomic.Int64
+	opFn := func() (map[string]float64, error) {
+		task := tasks[int(rr.Add(1))%len(tasks)]
+		return d.execOnce(ctx, task, tty)
+	}
+	m := d.measure(ctx, rt, d.cfg.Iterations, parallel, opFn)
+	name := "exec"
+	if tty {
+		name = "exec-tty"
+	}
+	return buildResult(name, rt, variant, parallel, m), nil
+}
+
+// scenarioStatus times State (task.Status) and Stats (task.Metrics) collection
+// across a pool of running containers under P concurrent workers.
+func (d *driver) scenarioStatus(ctx context.Context, rt string, parallel int) (ScenarioResult, error) {
+	tasks, teardown, err := d.taskPool(ctx, rt, "statusbase", statusPoolSize)
+	if err != nil {
+		return ScenarioResult{}, err
+	}
+	defer teardown()
+
+	var rr atomic.Int64
+	opFn := func() (map[string]float64, error) {
+		task := tasks[int(rr.Add(1))%len(tasks)]
+		ops := map[string]float64{}
+		t0 := time.Now()
+		_, err := task.Status(ctx)
+		ops["state"] = msSince(t0)
+		if err != nil {
+			return ops, err
+		}
+		t1 := time.Now()
+		_, err = task.Metrics(ctx)
+		ops["stats"] = msSince(t1)
+		if err != nil {
+			return ops, err
+		}
+		return ops, nil
+	}
+	m := d.measure(ctx, rt, d.cfg.StatusLoops, parallel, opFn)
+	return buildResult("status", rt, "", parallel, m), nil
+}
+
+// scenarioScale brings up `count` long-running containers concurrently, holds
+// them at steady state while sampling aggregate resource use, then tears them
+// down. This is the 1-daemon-vs-N-shims footprint measurement.
+func (d *driver) scenarioScale(ctx context.Context, rt string, count int) (ScenarioResult, error) {
+	maxPar := max(1, slices.Max(d.cfg.Parallel))
+
+	scrape := rt == runtimeSystemd && d.cfg.ShimVarsURL != ""
+	var before *ShimVarsSnapshot
+	if scrape {
+		before, _ = scrapeShimVars(ctx, d.cfg.ShimVarsURL)
+	}
+
+	smp := newSampler(d.cfg.SampleInterval)
+	smp.start()
+
+	var mu sync.Mutex
+	var teardowns []func()
+	launchFn := func() (map[string]float64, error) {
+		t0 := time.Now()
+		task, td, err := d.longContainer(ctx, rt, d.uid("scale"))
+		dur := msSince(t0)
+		if err != nil {
+			return map[string]float64{"launch": dur}, err
+		}
+		_ = task
+		mu.Lock()
+		teardowns = append(teardowns, td)
+		mu.Unlock()
+		return map[string]float64{"launch": dur}, nil
+	}
+
+	raw, errs, wall := runConcurrentN(count, maxPar, launchFn)
+	if d.cfg.ScaleHold > 0 {
+		time.Sleep(d.cfg.ScaleHold)
+	}
+	sres := smp.stopAndCollect()
+
+	var vars *ShimVarsDelta
+	var goHeap uint64
+	if scrape {
+		after, _ := scrapeShimVars(ctx, d.cfg.ShimVarsURL)
+		vars = diffShimVars(before, after)
+		if after != nil {
+			goHeap = after.GoHeapAlloc
+		}
+	}
+
+	mu.Lock()
+	tds := teardowns
+	mu.Unlock()
+	for _, td := range tds {
+		td()
+	}
+
+	m := measuredOut{raw: raw, errs: errs, wall: wall, count: count, sample: sres, vars: vars, goHeap: goHeap}
+	r := buildResult("scale", rt, "", 0, m)
+	r.ScaleCount = count
+	if wall > 0 {
+		r.ThroughputOpsPerSec = float64(count-errs) / wall.Seconds()
+	}
+	return r, nil
+}
+
+// taskPool creates n running containers and returns their tasks plus a single
+// teardown func that cleans them all up.
+func (d *driver) taskPool(ctx context.Context, rt, prefix string, n int) ([]containerd.Task, func(), error) {
+	var tasks []containerd.Task
+	var teardowns []func()
+	cleanup := func() {
+		for _, td := range teardowns {
+			td()
+		}
+	}
+	for range n {
+		task, td, err := d.longContainer(ctx, rt, d.uid(prefix))
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+		tasks = append(tasks, task)
+		teardowns = append(teardowns, td)
+	}
+	return tasks, cleanup, nil
+}
+
+func convertCatMapToStringMap[T any](input map[category]T) map[string]T {
+	out := make(map[string]T)
+	for k, v := range input {
+		out[string(k)] = v
+	}
+	return out
+}

--- a/contrib/bench/scrape.go
+++ b/contrib/bench/scrape.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// ShimVarsSnapshot is a point-in-time read of the systemd shim's expvar
+// counters (published at /debug/vars). runc.v2 has no such endpoint, so these
+// are shim-internal diagnostics rather than a head-to-head comparison metric.
+type ShimVarsSnapshot struct {
+	ReactorHits     int64
+	GetAllFallbacks int64
+	OnDiskReads     int64
+	GetUnitCalls    int64
+	ReloadCount     int64
+	ReloadNanos     int64
+	GoHeapAlloc     uint64
+}
+
+// ShimVarsDelta is the difference between two snapshots over a scenario window.
+type ShimVarsDelta struct {
+	ReactorHits     int64   `json:"reactor_hits"`
+	GetAllFallbacks int64   `json:"getall_fallbacks"`
+	OnDiskReads     int64   `json:"ondisk_reads"`
+	GetUnitCalls    int64   `json:"getunitstate_calls"`
+	ReactorHitRate  float64 `json:"reactor_hit_rate"`
+	ReloadCount     int64   `json:"daemon_reload_count"`
+	ReloadTotalMs   float64 `json:"daemon_reload_total_ms"`
+	ReloadMeanMs    float64 `json:"daemon_reload_mean_ms"`
+}
+
+// scrapeShimVars fetches and parses the shim's expvar endpoint. It returns
+// (nil, nil) when url is empty so callers can treat "no endpoint" and "runc
+// runtime" uniformly.
+func scrapeShimVars(ctx context.Context, url string) (*ShimVarsSnapshot, error) {
+	if url == "" {
+		return nil, nil
+	}
+	ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("shim vars: unexpected status %s", resp.Status)
+	}
+
+	var raw struct {
+		ShimState struct {
+			ReactorHits int64 `json:"exitstate_reactor_hits"`
+			GetAll      int64 `json:"exitstate_getall_fallbacks"`
+			OnDisk      int64 `json:"state_ondisk_reads"`
+			GetUnit     int64 `json:"getunitstate_calls"`
+			ReloadCount int64 `json:"daemon_reload_count"`
+			ReloadNanos int64 `json:"daemon_reload_nanos"`
+		} `json:"shim_state"`
+		Memstats struct {
+			Alloc uint64 `json:"Alloc"`
+		} `json:"memstats"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		return nil, err
+	}
+	return &ShimVarsSnapshot{
+		ReactorHits:     raw.ShimState.ReactorHits,
+		GetAllFallbacks: raw.ShimState.GetAll,
+		OnDiskReads:     raw.ShimState.OnDisk,
+		GetUnitCalls:    raw.ShimState.GetUnit,
+		ReloadCount:     raw.ShimState.ReloadCount,
+		ReloadNanos:     raw.ShimState.ReloadNanos,
+		GoHeapAlloc:     raw.Memstats.Alloc,
+	}, nil
+}
+
+// diffShimVars computes before→after deltas and the reactor hit rate.
+func diffShimVars(before, after *ShimVarsSnapshot) *ShimVarsDelta {
+	if before == nil || after == nil {
+		return nil
+	}
+	d := &ShimVarsDelta{
+		ReactorHits:     after.ReactorHits - before.ReactorHits,
+		GetAllFallbacks: after.GetAllFallbacks - before.GetAllFallbacks,
+		OnDiskReads:     after.OnDiskReads - before.OnDiskReads,
+		GetUnitCalls:    after.GetUnitCalls - before.GetUnitCalls,
+		ReloadCount:     after.ReloadCount - before.ReloadCount,
+		ReloadTotalMs:   float64(after.ReloadNanos-before.ReloadNanos) / 1e6,
+	}
+	if total := d.ReactorHits + d.GetAllFallbacks; total > 0 {
+		d.ReactorHitRate = float64(d.ReactorHits) / float64(total)
+	}
+	if d.ReloadCount > 0 {
+		d.ReloadMeanMs = d.ReloadTotalMs / float64(d.ReloadCount)
+	}
+	return d
+}

--- a/contrib/bench/stats.go
+++ b/contrib/bench/stats.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"math"
+	"sort"
+)
+
+// summarize computes latency distribution stats (in ms) from a slice of
+// durations expressed as float64 milliseconds. keepRaw controls whether the
+// raw samples are retained in the result (useful for regenerating charts).
+func summarize(msValues []float64, keepRaw bool) OpStats {
+	n := len(msValues)
+	if n == 0 {
+		return OpStats{}
+	}
+	sorted := make([]float64, n)
+	copy(sorted, msValues)
+	sort.Float64s(sorted)
+
+	var sum float64
+	for _, v := range sorted {
+		sum += v
+	}
+	mean := sum / float64(n)
+
+	var sq float64
+	for _, v := range sorted {
+		d := v - mean
+		sq += d * d
+	}
+	stddev := 0.0
+	if n > 1 {
+		stddev = math.Sqrt(sq / float64(n-1))
+	}
+
+	st := OpStats{
+		Count:  n,
+		Min:    sorted[0],
+		P50:    percentile(sorted, 50),
+		P90:    percentile(sorted, 90),
+		P99:    percentile(sorted, 99),
+		Max:    sorted[n-1],
+		Mean:   mean,
+		Stddev: stddev,
+	}
+	if keepRaw {
+		st.Raw = msValues
+	}
+	return st
+}
+
+// percentile returns the p-th percentile (0-100) of an already-sorted slice
+// using linear interpolation between closest ranks.
+func percentile(sorted []float64, p float64) float64 {
+	n := len(sorted)
+	if n == 0 {
+		return 0
+	}
+	if n == 1 {
+		return sorted[0]
+	}
+	rank := (p / 100) * float64(n-1)
+	lo := int(math.Floor(rank))
+	hi := int(math.Ceil(rank))
+	if lo == hi {
+		return sorted[lo]
+	}
+	frac := rank - float64(lo)
+	return sorted[lo]*(1-frac) + sorted[hi]*frac
+}

--- a/contrib/bench/styles.go
+++ b/contrib/bench/styles.go
@@ -1,0 +1,88 @@
+package main
+
+// reportCSS defines the validated reference palette as CSS custom properties
+// (light + dark, both selected) plus report layout and chart-element classes.
+// Chart SVGs reference these vars by role, so a single theme swap recolors all.
+const reportCSS = `
+:root, .viz {
+  --surface-1:#fcfcfb; --page:#f9f9f7;
+  --ink:#0b0b0b; --ink2:#52514e; --muted:#898781;
+  --grid:#e1e0d9; --axis:#c3c2b7; --border:rgba(11,11,11,0.10);
+  --rt-systemd:#2a78d6; --rt-runc:#eb6834;
+  --cat-1:#2a78d6; --cat-2:#008300; --cat-3:#e87ba4; --cat-4:#eda100; --cat-5:#1baf7a; --cat-6:#eb6834;
+  color-scheme:light;
+}
+@media (prefers-color-scheme: dark) {
+  :root:where(:not([data-theme="light"])) , :root:where(:not([data-theme="light"])) .viz {
+    --surface-1:#1a1a19; --page:#0d0d0d;
+    --ink:#ffffff; --ink2:#c3c2b7; --muted:#898781;
+    --grid:#2c2c2a; --axis:#383835; --border:rgba(255,255,255,0.10);
+    --rt-systemd:#3987e5; --rt-runc:#d95926;
+    --cat-1:#3987e5; --cat-2:#008300; --cat-3:#d55181; --cat-4:#c98500; --cat-5:#199e70; --cat-6:#d95926;
+    color-scheme:dark;
+  }
+}
+:root[data-theme="dark"], :root[data-theme="dark"] .viz {
+  --surface-1:#1a1a19; --page:#0d0d0d;
+  --ink:#ffffff; --ink2:#c3c2b7; --muted:#898781;
+  --grid:#2c2c2a; --axis:#383835; --border:rgba(255,255,255,0.10);
+  --rt-systemd:#3987e5; --rt-runc:#d95926;
+  --cat-1:#3987e5; --cat-2:#008300; --cat-3:#d55181; --cat-4:#c98500; --cat-5:#199e70; --cat-6:#d95926;
+  color-scheme:dark;
+}
+
+* { box-sizing:border-box; }
+body { margin:0; background:var(--page); color:var(--ink);
+  font-family: system-ui, -apple-system, "Segoe UI", sans-serif; font-size:14px; line-height:1.5; }
+h1 { font-size:22px; margin:0; }
+h2 { font-size:16px; margin:28px 20px 8px; }
+h3 { font-size:14px; margin:0 0 2px; }
+.sub { color:var(--ink2); margin:2px 0; }
+.top { display:flex; align-items:center; justify-content:space-between;
+  padding:20px; border-bottom:1px solid var(--border); }
+.toggle { background:var(--surface-1); color:var(--ink); border:1px solid var(--border);
+  border-radius:8px; padding:8px 12px; cursor:pointer; font:inherit; }
+.prov dl { display:grid; grid-template-columns:repeat(auto-fill,minmax(200px,1fr));
+  gap:2px 16px; margin:0 20px; }
+.prov dt { color:var(--muted); font-size:12px; }
+.prov dd { margin:0 0 6px; font-variant-numeric:tabular-nums; }
+.charts { display:grid; grid-template-columns:repeat(auto-fill,minmax(380px,1fr));
+  gap:16px; padding:8px 20px 20px; }
+.card { margin:0; background:var(--surface-1); border:1px solid var(--border);
+  border-radius:12px; padding:14px 14px 4px; }
+.card figcaption p { color:var(--ink2); font-size:12px; margin:0 0 6px; }
+.chart { width:100%; height:auto; display:block; }
+.chart .grid { stroke:var(--grid); stroke-width:1; }
+.chart .axis { stroke:var(--axis); stroke-width:1; }
+.chart .xlabel { fill:var(--ink2); font-size:11px; }
+.chart .ytick { fill:var(--muted); font-size:10px; font-variant-numeric:tabular-nums; }
+.chart .axislabel { fill:var(--muted); font-size:10px; }
+.chart .legend { fill:var(--ink2); font-size:11px; }
+.chart .vlabel { fill:var(--ink2); font-size:9px; font-variant-numeric:tabular-nums; }
+.tablewrap { padding:0 20px 20px; overflow-x:auto; }
+table { border-collapse:collapse; width:100%; font-size:12px; }
+th, td { text-align:right; padding:5px 8px; border-bottom:1px solid var(--border);
+  font-variant-numeric:tabular-nums; white-space:nowrap; }
+th:first-child, td:first-child, th:nth-child(2), td:nth-child(2), th:nth-child(3), td:nth-child(3) { text-align:left; }
+thead th { color:var(--muted); font-weight:600; border-bottom:1px solid var(--axis); }
+.caveats { padding:0 20px 40px; color:var(--ink2); max-width:70ch; }
+.caveats li { margin:6px 0; }
+code { background:var(--surface-1); border:1px solid var(--border); border-radius:4px; padding:1px 5px; }
+`
+
+// themeJS toggles between OS-follow, forced light, and forced dark by setting
+// data-theme on <html>.
+const themeJS = `
+(function(){
+  var btn = document.getElementById('themeToggle');
+  if(!btn) return;
+  var order = [null, 'light', 'dark'];
+  var i = 0;
+  btn.addEventListener('click', function(){
+    i = (i+1) % order.length;
+    if(order[i]) document.documentElement.setAttribute('data-theme', order[i]);
+    else document.documentElement.removeAttribute('data-theme');
+    btn.textContent = '◐ ' + (order[i] || 'auto');
+  });
+})();
+`

--- a/contrib/bench/types.go
+++ b/contrib/bench/types.go
@@ -1,0 +1,96 @@
+package main
+
+import "time"
+
+// runtime identifiers under comparison.
+const (
+	runtimeSystemd = "io.containerd.systemd.v1"
+	runtimeRunc    = "io.containerd.runc.v2"
+)
+
+// Config is the fully-resolved benchmark configuration for a run.
+type Config struct {
+	Address        string        `json:"address"`
+	Runtimes       []string      `json:"runtimes"`
+	Image          string        `json:"image"`
+	Namespace      string        `json:"namespace"`
+	Iterations     int           `json:"iterations"`
+	Warmup         int           `json:"warmup"`
+	Parallel       []int         `json:"parallel"`
+	ScaleCounts    []int         `json:"scale_counts"`
+	Scenarios      []string      `json:"scenarios"`
+	Out            string        `json:"out"`
+	ShimVarsURL    string        `json:"shim_vars_url"`
+	SampleInterval time.Duration `json:"sample_interval_ns"`
+	StatusLoops    int           `json:"status_loops"`
+	ScaleHold      time.Duration `json:"scale_hold_ns"`
+}
+
+// Report is the top-level output written to results.json.
+type Report struct {
+	Env       Env              `json:"env"`
+	StartedAt string           `json:"started_at"`
+	Config    Config           `json:"config"`
+	Scenarios []ScenarioResult `json:"scenarios"`
+}
+
+// Env captures provenance so a results file is self-describing.
+type Env struct {
+	Hostname         string `json:"hostname"`
+	Kernel           string `json:"kernel"`
+	Arch             string `json:"arch"`
+	NumCPU           int    `json:"num_cpu"`
+	MemTotalBytes    uint64 `json:"mem_total_bytes"`
+	CgroupVersion    string `json:"cgroup_version"`
+	GoVersion        string `json:"go_version"`
+	ContainerdVer    string `json:"containerd_version"`
+	RuncVersion      string `json:"runc_version"`
+	HarnessGitCommit string `json:"harness_git_commit"`
+	ClockTicksHz     int    `json:"clock_ticks_hz"`
+	InsideVM         bool   `json:"inside_vm"`
+}
+
+// ScenarioResult holds one measured (scenario, runtime, parallelism|scale) cell.
+type ScenarioResult struct {
+	Scenario            string             `json:"scenario"`
+	Runtime             string             `json:"runtime"`
+	Variant             string             `json:"variant,omitempty"`
+	Parallel            int                `json:"parallel,omitempty"`
+	ScaleCount          int                `json:"scale_count,omitempty"`
+	Iterations          int                `json:"iterations"`
+	Errors              int                `json:"errors"`
+	WallSeconds         float64            `json:"wall_seconds"`
+	ThroughputOpsPerSec float64            `json:"throughput_ops_per_sec,omitempty"`
+	Ops                 map[string]OpStats `json:"ops,omitempty"`
+	CPUSeconds          map[string]float64 `json:"cpu_seconds,omitempty"`
+	SystemCPUSeconds    float64            `json:"system_cpu_seconds"`
+	HarnessCPUSeconds   float64            `json:"harness_cpu_seconds"`
+	AttribCPUSeconds    float64            `json:"attrib_cpu_seconds"`
+	SystemUtilPct       float64            `json:"system_util_pct"`
+	ShimCgroupCPUSecond float64            `json:"shim_cgroup_cpu_seconds,omitempty"`
+	MemPeakPss          map[string]uint64  `json:"mem_peak_pss_bytes,omitempty"`
+	MemMeanPss          map[string]uint64  `json:"mem_mean_pss_bytes,omitempty"`
+	ShimVars            *ShimVarsDelta     `json:"shim_vars_delta,omitempty"`
+	ShimGoHeapBytes     uint64             `json:"shim_go_heap_bytes,omitempty"`
+	Series              []SamplePoint      `json:"series,omitempty"`
+}
+
+// OpStats is the latency distribution for a single named operation, in ms.
+type OpStats struct {
+	Count  int       `json:"count"`
+	Min    float64   `json:"min_ms"`
+	P50    float64   `json:"p50_ms"`
+	P90    float64   `json:"p90_ms"`
+	P99    float64   `json:"p99_ms"`
+	Max    float64   `json:"max_ms"`
+	Mean   float64   `json:"mean_ms"`
+	Stddev float64   `json:"stddev_ms"`
+	Raw    []float64 `json:"raw_ms,omitempty"`
+}
+
+// SamplePoint is one downsampled point in a scenario's resource time series.
+type SamplePoint struct {
+	TSeconds float64            `json:"t_seconds"`
+	PssBytes map[string]uint64  `json:"pss_bytes"`
+	CPUPct   map[string]float64 `json:"cpu_pct"`
+}

--- a/create.go
+++ b/create.go
@@ -334,7 +334,7 @@ func (p *execProcess) Create(ctx context.Context) error {
 	if err := writeUnit(p.unitPath(), opts); err != nil {
 		return err
 	}
-	if err := p.systemd.ReloadContext(ctx); err != nil {
+	if err := reloadSystemd(ctx, p.systemd); err != nil {
 		log.G(ctx).WithError(err).Warn("failed to reload systemd")
 	}
 	// Make sure we don't have some old state from a past run.
@@ -413,7 +413,7 @@ func (p *initProcess) createRestore(ctx context.Context) error {
 	if err := writeUnit(p.unitPath(), unitOpts); err != nil {
 		return err
 	}
-	if err := p.systemd.ReloadContext(ctx); err != nil {
+	if err := reloadSystemd(ctx, p.systemd); err != nil {
 		log.G(ctx).WithError(err).Warn("Error reloading systemd")
 	}
 
@@ -486,7 +486,7 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 	if err := writeUnit(p.unitPath(), unitOpts); err != nil {
 		return 0, err
 	}
-	if err := p.systemd.ReloadContext(ctx); err != nil {
+	if err := reloadSystemd(ctx, p.systemd); err != nil {
 		log.G(ctx).WithError(err).Warn("Error reloading systemd")
 	}
 	// Make sure we don't have some old state from a past run.

--- a/delete.go
+++ b/delete.go
@@ -151,7 +151,7 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 	if err := os.Remove(p.unitPath()); err != nil {
 		return pState{}, err
 	}
-	if err := p.systemd.ReloadContext(ctx); err != nil {
+	if err := reloadSystemd(ctx, p.systemd); err != nil {
 		log.G(ctx).WithError(err).Error("systemd reload failed")
 	}
 
@@ -227,7 +227,7 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 		log.G(ctx).WithError(err).Debug("Failed to remove exec unit")
 	}
 
-	if err := p.systemd.ReloadContext(ctx); err != nil {
+	if err := reloadSystemd(ctx, p.systemd); err != nil {
 		log.G(ctx).WithError(err).Error("systemd reload failed")
 	}
 	p.systemd.ResetFailedUnitContext(ctx, p.Name())

--- a/flake.nix
+++ b/flake.nix
@@ -43,11 +43,12 @@
               && !(pkgs.lib.hasSuffix ".test" base);
           };
 
-          vendorHash = "sha256-pdxiz90QkiN3P2dMP+Kv/KQHH+Os8f2mKPtHTDStXKg=";
+          vendorHash = "sha256-Btom6v1OCfXHudfhXLvj17GmzeEiFIUtk6FbWmDWKnA=";
 
           subPackages = [
             "."
             "contrib/checkexec"
+            "contrib/bench"
           ];
 
           # The unit tests need a live systemd bus; run them from the devShell or
@@ -186,6 +187,66 @@
 
           system.stateVersion = "24.11";
         };
+
+      # benchRunnerModule turns the dev VM into a headless benchmark runner: on
+      # boot it runs the shim-vs-runc.v2 benchmark, writes results to a
+      # host-shared directory, then powers the VM off (so `nix run` returns).
+      # The disk is ephemeral and results land on the host at the source path.
+      benchRunnerModule =
+        { pkgs, ... }:
+        let
+          shim = mkShim pkgs;
+          outDir = "/mnt/bench-out";
+        in
+        {
+          virtualisation.diskImage = null;
+
+          virtualisation.sharedDirectories.benchout = {
+            source = "/tmp/shim-bench-out";
+            target = outDir;
+          };
+
+          systemd.services.bench-runner = {
+            description = "Run the shim benchmark headless, then power off";
+            wantedBy = [ "multi-user.target" ];
+            wants = [ "network-online.target" ];
+            after = [
+              "containerd.service"
+              "network-online.target"
+              "containerd-shim-systemd-v1.socket"
+            ];
+            path = [
+              shim
+              pkgs.runc
+              pkgs.iptables
+              pkgs.coreutils
+            ];
+            serviceConfig = {
+              Type = "oneshot";
+              ExecStopPost = "${pkgs.systemd}/bin/systemctl poweroff";
+              StandardOutput = "journal+console";
+              StandardError = "journal+console";
+            };
+            script = ''
+              set -x
+              until [ -S /run/containerd/containerd.sock ]; do sleep 1; done
+              out="${outDir}/run"
+              rm -rf "$out"
+              mkdir -p "$out"
+              bench \
+                -containerd-address=/run/containerd/containerd.sock \
+                -runtimes=io.containerd.runc.v2,io.containerd.systemd.v1 \
+                -iterations=20 -warmup=3 \
+                -parallel=1,4,8 \
+                -scale-counts=1,5,10,25 \
+                -status-loops=300 \
+                -scenarios=container,exec,status,container-tty,exec-tty,scale \
+                -out="$out" > "$out/bench.log" 2>&1
+              echo $? > "$out/exit-code"
+              sync
+            '';
+          };
+        };
     in
     {
       packages = forAllSystems (pkgs: {
@@ -207,9 +268,36 @@
         ];
       };
 
+      nixosConfigurations.benchvm = nixpkgs.lib.nixosSystem {
+        system = "x86_64-linux";
+        modules = [
+          shimModule
+          vmModule
+          benchRunnerModule
+        ];
+      };
+
       apps.x86_64-linux.vm = {
         type = "app";
         program = "${self.nixosConfigurations.vm.config.system.build.vm}/bin/run-shim-dev-vm";
+      };
+
+      apps.x86_64-linux.benchvm = {
+        type = "app";
+        program =
+          let
+            pkgs = nixpkgs.legacyPackages.x86_64-linux;
+            vm = self.nixosConfigurations.benchvm.config.system.build.vm;
+          in
+          "${pkgs.writeShellScript "run-benchvm" ''
+            # The 9p share source must exist on the host before QEMU starts.
+            mkdir -p /tmp/shim-bench-out
+            rm -f /tmp/shim-bench-out/run/exit-code
+            ${vm}/bin/run-shim-dev-vm "$@"
+            # QEMU always exits 0 (the VM powers itself off), so surface the
+            # in-VM benchmark's real exit status to the caller.
+            exit "$(cat /tmp/shim-bench-out/run/exit-code 2>/dev/null || echo 1)"
+          ''}";
       };
 
       devShells = forAllSystems (pkgs: {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.3
 
 require (
 	github.com/containerd/cgroups/v3 v3.1.3
+	github.com/containerd/console v1.0.5
 	github.com/containerd/containerd/api v1.11.1
 	github.com/containerd/containerd/v2 v2.3.3
 	github.com/containerd/errdefs v1.0.0
@@ -36,7 +37,6 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cilium/ebpf v0.17.3 // indirect
-	github.com/containerd/console v1.0.5 // indirect
 	github.com/containerd/continuity v0.5.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
 	github.com/containerd/platforms v1.0.0-rc.4 // indirect

--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import "C"
 import (
 	"context"
 	"errors"
+	"expvar"
 	"flag"
 	"fmt"
 	"io"
@@ -407,6 +408,7 @@ func serve(ctx context.Context, cfg Config) error {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/profile", pprof.Profile)
+	mux.Handle("/debug/vars", expvar.Handler())
 	go func() {
 		if err := http.ListenAndServe("127.0.0.1:8089", mux); err != nil {
 			log.G(ctx).WithError(err).Fatal("ListenAndServe")

--- a/metrics.go
+++ b/metrics.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"expvar"
+	"time"
+
+	"github.com/coreos/go-systemd/v22/dbus"
+)
+
+// State-source metric keys. These count how the shim answers process
+// state/exit queries: from the in-memory D-Bus event reactor (the fast path)
+// versus falling back to a systemd GetAll property read or an on-disk exit
+// file. The reactor-hit vs getall-fallback ratio is the event reactor's
+// effective hit rate; on-disk reads are the other fallback source.
+//
+// daemon_reload_* measure time spent in systemd `daemon-reload` (Reload over
+// D-Bus), which the shim issues on every create/delete because it writes unit
+// files to disk. daemon-reload re-parses every unit, so its cost grows with the
+// number of units on the host — a prime suspect for create/delete latency.
+const (
+	metricReactorHits       = "exitstate_reactor_hits"
+	metricGetAllFallbacks   = "exitstate_getall_fallbacks"
+	metricOnDiskReads       = "state_ondisk_reads"
+	metricGetUnitCalls      = "getunitstate_calls"
+	metricDaemonReloadCount = "daemon_reload_count"
+	metricDaemonReloadNanos = "daemon_reload_nanos"
+)
+
+// stateMetrics is published at /debug/vars (wired in serve()). Counters are
+// cumulative for the process lifetime; consumers diff two snapshots to get a
+// per-window rate. All keys are published up front (as 0) so scrapers see a
+// stable schema before the first event arrives.
+var stateMetrics = func() *expvar.Map {
+	m := expvar.NewMap("shim_state")
+	for _, k := range []string{
+		metricReactorHits,
+		metricGetAllFallbacks,
+		metricOnDiskReads,
+		metricGetUnitCalls,
+		metricDaemonReloadCount,
+		metricDaemonReloadNanos,
+	} {
+		m.Add(k, 0)
+	}
+	return m
+}()
+
+// countState increments one of the state-source counters above.
+func countState(key string) { stateMetrics.Add(key, 1) }
+
+// reloadSystemd issues a systemd daemon-reload and records how long it took.
+// The count and cumulative duration are exposed via expvar so the benchmark can
+// attribute create/delete latency to reload cost. Reloads are timed even on
+// error, since the time was still spent.
+func reloadSystemd(ctx context.Context, conn *dbus.Conn) error {
+	start := time.Now()
+	err := conn.ReloadContext(ctx)
+	stateMetrics.Add(metricDaemonReloadCount, 1)
+	stateMetrics.Add(metricDaemonReloadNanos, int64(time.Since(start)))
+	return err
+}

--- a/state.go
+++ b/state.go
@@ -80,6 +80,7 @@ func (s *Service) State(ctx context.Context, r *taskapi.StateRequest) (_ *taskap
 }
 
 func getUnitState(ctx context.Context, conn *dbus.Conn, unit string, st *pState) error {
+	countState(metricGetUnitCalls)
 	state, err := conn.GetAllPropertiesContext(ctx, unit)
 	if err != nil {
 		return err
@@ -194,12 +195,18 @@ func loadExitFromUnit(ctx context.Context, conn *dbus.Conn, name string) (pState
 
 func (p *initProcess) LoadExitState(ctx context.Context) error {
 	if st, ok := p.loadRecordedSystemdExitState(); ok {
+		countState(metricReactorHits)
 		p.SetState(ctx, st)
 		return nil
 	}
 	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
 	if err != nil {
 		return err
+	}
+	// Count a fallback only when GetAll actually recovered a terminal exit the
+	// reactor missed; a pre-start / non-terminal read is not a reactor miss.
+	if st.Exited() {
+		countState(metricGetAllFallbacks)
 	}
 	p.SetState(ctx, st)
 	return nil
@@ -207,12 +214,18 @@ func (p *initProcess) LoadExitState(ctx context.Context) error {
 
 func (p *execProcess) LoadExitState(ctx context.Context) error {
 	if st, ok := p.loadRecordedSystemdExitState(); ok {
+		countState(metricReactorHits)
 		p.SetState(ctx, st)
 		return nil
 	}
 	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
 	if err != nil {
 		return err
+	}
+	// Count a fallback only when GetAll actually recovered a terminal exit the
+	// reactor missed; a pre-start / non-terminal read is not a reactor miss.
+	if st.Exited() {
+		countState(metricGetAllFallbacks)
 	}
 	p.SetState(ctx, st)
 	return nil
@@ -227,7 +240,11 @@ func (p *execProcess) readExitState(st *pState) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, st)
+	if err := json.Unmarshal(data, st); err != nil {
+		return err
+	}
+	countState(metricOnDiskReads)
+	return nil
 }
 
 func (p *initProcess) exitStatePath() string {
@@ -239,7 +256,11 @@ func (p *initProcess) readExitState(st *pState) error {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, st)
+	if err := json.Unmarshal(data, st); err != nil {
+		return err
+	}
+	countState(metricOnDiskReads)
+	return nil
 }
 
 func (p *execProcess) State(ctx context.Context) (*State, error) {


### PR DESCRIPTION
Adds internal instrumentation to the shim plus a harness to benchmark it
against `io.containerd.runc.v2`.

## Instrumentation
Publishes expvar counters at `/debug/vars` (on the existing `127.0.0.1:8089`
mux): exit-state source — D-Bus reactor hit vs systemd `GetAll` / on-disk
fallback — and `daemon-reload` count + total duration. Makes the shim's
state-source and reload behavior directly measurable.

## Harness (`contrib/bench`)
A containerd-client driver that runs the same task lifecycle through both
runtimes (only the runtime string differs) and reports latency, concurrency
(throughput and tail latency vs parallelism), CPU, memory (Pss), and TTY as a
distinct scenario. Emits raw JSON/CSV and a self-contained HTML report. Run via
`make bench` or the headless `nix run .#benchvm`.