### PR TITLE
Run container and exec units as systemd transient units

### DIFF
--- a/contrib/bench/html.go
+++ b/contrib/bench/html.go
@@ -115,9 +115,6 @@ func writeCharts(b *strings.Builder, r *Report) {
 	section(fmt.Sprintf("CPU by process category — container @ p=%d (breakdown)", maxP),
 		"Per-process attribution. Long-lived (shim daemon, PID1, containerd) is exact; short-lived runc / per-container shims are undercounted by sampling — use the fair total above.",
 		chartCPUByCategory(r, maxP))
-	section("systemd daemon-reload time per container op",
-		"Time in systemd daemon-reload (re-parses every unit), which the shim issues on each create and delete. ms per lifecycle.",
-		chartReload(r))
 
 	// Shim-internal fallback (systemd only).
 	section("Exit-state source: reactor vs GetAll (systemd shim)",
@@ -293,40 +290,6 @@ func chartAttribCPU(r *Report, scenario string) string {
 	return groupedBars("cpu/op", "ms/op", cats, groups)
 }
 
-func chartReload(r *Report) string {
-	order := []string{"container", "exec", "container-tty", "exec-tty", "status", "scale"}
-	type agg struct {
-		ms    float64
-		iters int
-	}
-	sums := map[string]*agg{}
-	for i := range r.Scenarios {
-		s := &r.Scenarios[i]
-		if s.Runtime != runtimeSystemd || s.ShimVars == nil {
-			continue
-		}
-		a := sums[s.Scenario]
-		if a == nil {
-			a = &agg{}
-			sums[s.Scenario] = a
-		}
-		a.ms += s.ShimVars.ReloadTotalMs
-		a.iters += s.Iterations
-	}
-	var cats []string
-	var vals []float64
-	for _, name := range order {
-		if a, ok := sums[name]; ok && a.iters > 0 {
-			cats = append(cats, name)
-			vals = append(vals, a.ms/float64(a.iters))
-		}
-	}
-	if len(cats) == 0 {
-		return ""
-	}
-	return groupedBars("reload", "ms/op", cats, []barGroup{{"systemd daemon-reload", "var(--cat-6)", vals}})
-}
-
 func chartFallback(r *Report) string {
 	// aggregate systemd shim counters per scenario name
 	order := []string{"container", "exec", "exec-tty", "container-tty", "status", "scale"}
@@ -378,7 +341,7 @@ func writeDataTable(b *strings.Builder, r *Report) {
 	b.WriteString(`<section class="tablewrap"><h2>all measurements</h2>`)
 	b.WriteString(`<p class="sub">Full raw data in <code>results.json</code>, <code>latency.csv</code>, <code>resources.csv</code>.</p>`)
 	b.WriteString(`<table><thead><tr>`)
-	for _, h := range []string{"scenario", "runtime", "variant", "P", "N", "iters", "err", "thrpt/s", "hdln p50", "hdln p99", "cpu/op ms", "reload/op ms", "shim peak", "hit rate"} {
+	for _, h := range []string{"scenario", "runtime", "variant", "P", "N", "iters", "err", "thrpt/s", "hdln p50", "hdln p99", "cpu/op ms", "shim peak", "hit rate"} {
 		fmt.Fprintf(b, `<th>%s</th>`, h)
 	}
 	b.WriteString(`</tr></thead><tbody>`)
@@ -386,12 +349,8 @@ func writeDataTable(b *strings.Builder, r *Report) {
 		s := &r.Scenarios[i]
 		op := headlineOp(s.Scenario)
 		hitRate := ""
-		reloadPerOp := ""
 		if s.ShimVars != nil {
 			hitRate = fmt.Sprintf("%.0f%%", s.ShimVars.ReactorHitRate*100)
-			if s.Iterations > 0 {
-				reloadPerOp = fmt.Sprintf("%.1f", s.ShimVars.ReloadTotalMs/float64(s.Iterations))
-			}
 		}
 		cpuPerOp := ""
 		if s.Iterations > 0 {
@@ -405,7 +364,6 @@ func writeDataTable(b *strings.Builder, r *Report) {
 			fmt.Sprintf("%.2f", p50Op(s, op)),
 			fmt.Sprintf("%.2f", p99Op(s, op)),
 			cpuPerOp,
-			reloadPerOp,
 			fmtBytes(shimPeakPss(s)),
 			hitRate,
 		}

--- a/contrib/bench/report.go
+++ b/contrib/bench/report.go
@@ -77,7 +77,7 @@ func writeResourceCSV(path string, r *Report) error {
 		header = append(header, "peak_pss_"+string(c))
 	}
 	header = append(header, "reactor_hits", "getall_fallbacks", "ondisk_reads", "reactor_hit_rate",
-		"daemon_reload_count", "daemon_reload_total_ms", "daemon_reload_mean_ms", "shim_go_heap_bytes")
+		"shim_go_heap_bytes")
 	w.Write(header)
 
 	for _, s := range r.Scenarios {
@@ -97,12 +97,9 @@ func writeResourceCSV(path string, r *Report) error {
 			row = append(row, strconv.FormatInt(s.ShimVars.ReactorHits, 10),
 				strconv.FormatInt(s.ShimVars.GetAllFallbacks, 10),
 				strconv.FormatInt(s.ShimVars.OnDiskReads, 10),
-				f2(s.ShimVars.ReactorHitRate),
-				strconv.FormatInt(s.ShimVars.ReloadCount, 10),
-				f2(s.ShimVars.ReloadTotalMs),
-				f2(s.ShimVars.ReloadMeanMs))
+				f2(s.ShimVars.ReactorHitRate))
 		} else {
-			row = append(row, "", "", "", "", "", "", "")
+			row = append(row, "", "", "", "")
 		}
 		row = append(row, strconv.FormatUint(s.ShimGoHeapBytes, 10))
 		w.Write(row)

--- a/contrib/bench/report_test.go
+++ b/contrib/bench/report_test.go
@@ -120,8 +120,7 @@ func syntheticReport() Report {
 		return map[string]uint64{"shim-systemd": shim, "tty-helper": 0, "shim-runc": shim, "runc": 4 << 20, "systemd": 20 << 20, "containerd": 30 << 20}
 	}
 	vars := func(hit, getall, ondisk int64) *ShimVarsDelta {
-		d := &ShimVarsDelta{ReactorHits: hit, GetAllFallbacks: getall, OnDiskReads: ondisk,
-			ReloadCount: 40, ReloadTotalMs: 400, ReloadMeanMs: 10}
+		d := &ShimVarsDelta{ReactorHits: hit, GetAllFallbacks: getall, OnDiskReads: ondisk}
 		if hit+getall > 0 {
 			d.ReactorHitRate = float64(hit) / float64(hit+getall)
 		}

--- a/contrib/bench/scrape.go
+++ b/contrib/bench/scrape.go
@@ -16,8 +16,6 @@ type ShimVarsSnapshot struct {
 	GetAllFallbacks int64
 	OnDiskReads     int64
 	GetUnitCalls    int64
-	ReloadCount     int64
-	ReloadNanos     int64
 	GoHeapAlloc     uint64
 }
 
@@ -28,9 +26,6 @@ type ShimVarsDelta struct {
 	OnDiskReads     int64   `json:"ondisk_reads"`
 	GetUnitCalls    int64   `json:"getunitstate_calls"`
 	ReactorHitRate  float64 `json:"reactor_hit_rate"`
-	ReloadCount     int64   `json:"daemon_reload_count"`
-	ReloadTotalMs   float64 `json:"daemon_reload_total_ms"`
-	ReloadMeanMs    float64 `json:"daemon_reload_mean_ms"`
 }
 
 // scrapeShimVars fetches and parses the shim's expvar endpoint. It returns
@@ -62,8 +57,6 @@ func scrapeShimVars(ctx context.Context, url string) (*ShimVarsSnapshot, error) 
 			GetAll      int64 `json:"exitstate_getall_fallbacks"`
 			OnDisk      int64 `json:"state_ondisk_reads"`
 			GetUnit     int64 `json:"getunitstate_calls"`
-			ReloadCount int64 `json:"daemon_reload_count"`
-			ReloadNanos int64 `json:"daemon_reload_nanos"`
 		} `json:"shim_state"`
 		Memstats struct {
 			Alloc uint64 `json:"Alloc"`
@@ -77,8 +70,6 @@ func scrapeShimVars(ctx context.Context, url string) (*ShimVarsSnapshot, error) 
 		GetAllFallbacks: raw.ShimState.GetAll,
 		OnDiskReads:     raw.ShimState.OnDisk,
 		GetUnitCalls:    raw.ShimState.GetUnit,
-		ReloadCount:     raw.ShimState.ReloadCount,
-		ReloadNanos:     raw.ShimState.ReloadNanos,
 		GoHeapAlloc:     raw.Memstats.Alloc,
 	}, nil
 }
@@ -93,14 +84,9 @@ func diffShimVars(before, after *ShimVarsSnapshot) *ShimVarsDelta {
 		GetAllFallbacks: after.GetAllFallbacks - before.GetAllFallbacks,
 		OnDiskReads:     after.OnDiskReads - before.OnDiskReads,
 		GetUnitCalls:    after.GetUnitCalls - before.GetUnitCalls,
-		ReloadCount:     after.ReloadCount - before.ReloadCount,
-		ReloadTotalMs:   float64(after.ReloadNanos-before.ReloadNanos) / 1e6,
 	}
 	if total := d.ReactorHits + d.GetAllFallbacks; total > 0 {
 		d.ReactorHitRate = float64(d.ReactorHits) / float64(total)
-	}
-	if d.ReloadCount > 0 {
-		d.ReloadMeanMs = d.ReloadTotalMs / float64(d.ReloadCount)
 	}
 	return d
 }

--- a/create.go
+++ b/create.go
@@ -164,7 +164,6 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 			},
 			exe:        s.exe,
 			root:       r.Bundle,
-			unitDir:    s.unitDir,
 			shimCgroup: opts.ShimCgroup,
 		},
 		Bundle:           r.Bundle,
@@ -264,7 +263,6 @@ func (s *Service) Exec(ctx context.Context, r *taskapi.ExecProcessRequest) (_ *e
 			Terminal: r.Terminal,
 			systemd:  s.conn,
 			exe:      s.exe,
-			unitDir:  s.unitDir,
 			opts:     CreateOptions{LogMode: s.defaultLogMode.String()},
 			runc: &runc.Runc{
 				Debug:         s.debug,
@@ -326,22 +324,8 @@ func (p *execProcess) Create(ctx context.Context) error {
 		return err
 	}
 
-	opts, err := p.startOptions()
-	if err != nil {
-		return err
-	}
-
-	if err := writeUnit(p.unitPath(), opts); err != nil {
-		return err
-	}
-	if err := reloadSystemd(ctx, p.systemd); err != nil {
-		log.G(ctx).WithError(err).Warn("failed to reload systemd")
-	}
-	// Make sure we don't have some old state from a past run.
-	if err := p.systemd.ResetFailedUnitContext(ctx, p.Name()); err != nil && !strings.Contains(err.Error(), "not loaded") {
-		log.G(ctx).WithError(err).Warn("Failed to reset systemd unit")
-	}
-
+	// The transient unit is registered and started together in Start; nothing
+	// to create in systemd here.
 	return nil
 }
 
@@ -405,17 +389,12 @@ func (p *initProcess) createRestore(ctx context.Context) error {
 	}
 	execStart = append(execStart, p.opts.RestoreArgs()...)
 
-	unitOpts, err := p.startOptions(execStart)
+	unitProps, err := p.startProperties(execStart)
 	if err != nil {
 		return err
 	}
-
-	if err := writeUnit(p.unitPath(), unitOpts); err != nil {
-		return err
-	}
-	if err := reloadSystemd(ctx, p.systemd); err != nil {
-		log.G(ctx).WithError(err).Warn("Error reloading systemd")
-	}
+	// startUnit runs later (from Start -> restore); hold the properties until then.
+	p.unitProps = unitProps
 
 	return nil
 }
@@ -461,7 +440,7 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 		rcmd = append(rcmd, "--console-socket="+s)
 	}
 
-	unitOpts, err := p.startOptions(rcmd)
+	unitProps, err := p.startProperties(rcmd)
 	if err != nil {
 		return 0, err
 	}
@@ -483,17 +462,7 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 		}()
 	}
 
-	if err := writeUnit(p.unitPath(), unitOpts); err != nil {
-		return 0, err
-	}
-	if err := reloadSystemd(ctx, p.systemd); err != nil {
-		log.G(ctx).WithError(err).Warn("Error reloading systemd")
-	}
-	// Make sure we don't have some old state from a past run.
-	if err := p.systemd.ResetFailedUnitContext(ctx, p.Name()); err != nil && !strings.Contains(err.Error(), "not loaded") {
-		log.G(ctx).WithError(err).Warn("Failed to reset systemd unit")
-	}
-
+	p.unitProps = unitProps
 	return p.startUnit(ctx)
 }
 
@@ -504,7 +473,7 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 		p.clearRecordedSystemdExitState()
 		ch := make(chan string, 1)
 		p.systemd.ResetFailedUnitContext(ctx, p.Name())
-		if _, err := p.systemd.StartUnitContext(ctx, uName, "replace", ch); err != nil {
+		if _, err := p.systemd.StartTransientUnitContext(ctx, uName, "replace", p.unitProps, ch); err != nil {
 			if err := p.runc.Delete(ctx, p.id, &runc.DeleteOpts{Force: true}); err != nil && !strings.Contains(err.Error(), "not found") {
 				log.G(ctx).WithError(err).Info("Error deleting container in runc")
 			}
@@ -513,7 +482,7 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 			}
 
 			ch = make(chan string, 1)
-			if _, err := p.systemd.StartUnitContext(ctx, uName, "replace", ch); err != nil {
+			if _, err := p.systemd.StartTransientUnitContext(ctx, uName, "replace", p.unitProps, ch); err != nil {
 				return fmt.Errorf("error starting unit: %w", err)
 			}
 		}
@@ -595,11 +564,7 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 		if err := do(); err != nil {
 			ret := err
 			if p.runc.Debug {
-				ret = fmt.Errorf("%w:\n%s", err, p.Name())
-				unitData, err := os.ReadFile(p.unitPath())
-				if err == nil {
-					ret = fmt.Errorf("%w:\n%s", ret, string(unitData))
-				}
+				ret = fmt.Errorf("%w:\n%s\n%s", err, p.Name(), formatUnitProperties(p.unitProps))
 				logData, err := os.ReadFile(p.runc.Log)
 				if err == nil {
 					ret = fmt.Errorf("%w\n%s", ret, string(logData))

--- a/create.go
+++ b/create.go
@@ -153,6 +153,8 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 			Stderr:   r.Stderr,
 			Terminal: r.Terminal,
 			systemd:  s.conn,
+			pinConn:  s.pinConn,
+			pinRef:   s.pinRef,
 			runc: &runc.Runc{
 				Debug:         s.debug,
 				Command:       runcCommand,
@@ -188,6 +190,9 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 
 	defer func() {
 		if retErr != nil {
+			ctx, cancel := cleanupContext(ctx)
+			defer cancel()
+
 			p.SetState(ctx, pState{ExitCode: 255, ExitedAt: time.Now(), Status: "failed"})
 			log.G(ctx).WithError(retErr).Debug("Set state to failed")
 			s.processes.Delete(path.Join(ns, r.ID))
@@ -262,6 +267,8 @@ func (s *Service) Exec(ctx context.Context, r *taskapi.ExecProcessRequest) (_ *e
 			Stderr:   r.Stderr,
 			Terminal: r.Terminal,
 			systemd:  s.conn,
+			pinConn:  s.pinConn,
+			pinRef:   s.pinRef,
 			exe:      s.exe,
 			opts:     CreateOptions{LogMode: s.defaultLogMode.String()},
 			runc: &runc.Runc{
@@ -283,6 +290,18 @@ func (s *Service) Exec(ctx context.Context, r *taskapi.ExecProcessRequest) (_ *e
 	}
 
 	s.units.Add(ep)
+
+	// The container may have started being deleted while this exec was being
+	// registered, after the delete had already swept the exec list. Registering
+	// then checking means one of the two always sees the other: either the sweep
+	// finds this exec, or this sees the flag the delete set before sweeping. An
+	// exec left behind here would never be reachable to clean up.
+	if pInit.isDeleting() {
+		s.units.Delete(ep)
+		pInit.execs.Delete(r.ExecID)
+		return nil, fmt.Errorf("container %s is being deleted: %w", pInit.id, errdefs.ErrFailedPrecondition)
+	}
+
 	if err := ep.Create(ctx); err != nil {
 		s.units.Delete(ep)
 		pInit.execs.Delete(r.ExecID)
@@ -407,7 +426,9 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 	defer func() {
 		if retErr != nil {
 			span.SetStatus(codes.Error, retErr.Error())
-			p.runc.Delete(ctx, p.id, &runc.DeleteOpts{Force: true})
+			cleanupCtx, cancel := cleanupContext(ctx)
+			defer cancel()
+			p.runc.Delete(cleanupCtx, p.id, &runc.DeleteOpts{Force: true})
 			p.mu.Lock()
 			p.deleted = true
 			p.cond.Broadcast()
@@ -457,13 +478,19 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 
 		defer func() {
 			if retErr != nil {
-				p.systemd.KillUnitContext(ctx, u, int32(syscall.SIGKILL))
+				cleanupCtx, cancel := cleanupContext(ctx)
+				defer cancel()
+				p.systemd.KillUnitContext(cleanupCtx, u, int32(syscall.SIGKILL))
 			}
 		}()
 	}
 
 	p.unitProps = unitProps
-	return p.startUnit(ctx)
+	pid, err := p.startUnit(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return pid, nil
 }
 
 func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
@@ -473,7 +500,7 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 		p.clearRecordedSystemdExitState()
 		ch := make(chan string, 1)
 		p.systemd.ResetFailedUnitContext(ctx, p.Name())
-		if _, err := p.systemd.StartTransientUnitContext(ctx, uName, "replace", p.unitProps, ch); err != nil {
+		if err := p.startTransientUnit(ctx, uName, "replace", p.unitProps, ch); err != nil {
 			if err := p.runc.Delete(ctx, p.id, &runc.DeleteOpts{Force: true}); err != nil && !strings.Contains(err.Error(), "not found") {
 				log.G(ctx).WithError(err).Info("Error deleting container in runc")
 			}
@@ -482,7 +509,7 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 			}
 
 			ch = make(chan string, 1)
-			if _, err := p.systemd.StartTransientUnitContext(ctx, uName, "replace", p.unitProps, ch); err != nil {
+			if err := p.startTransientUnit(ctx, uName, "replace", p.unitProps, ch); err != nil {
 				return fmt.Errorf("error starting unit: %w", err)
 			}
 		}
@@ -556,6 +583,12 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 			return 0, ctx.Err()
 		case <-ch:
 		}
+
+		// The stopped attempt above still holds its AddRef reference, which keeps
+		// the unit loaded and would make the re-create below fail "already exists".
+		// Release it now that the unit is stopped so systemd can collect it; the
+		// retry's start takes a fresh reference.
+		p.releaseUnit(ctx, p.Name())
 
 		// Clean up old state and try again
 		if err2 := p.runc.Delete(ctx, p.id, &runc.DeleteOpts{Force: true}); err2 != nil {

--- a/delete.go
+++ b/delete.go
@@ -145,16 +145,9 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 		p.systemd.KillUnitContext(ctx, unitName(p.ns, p.id, "tty"), 9)
 	}
 
-	// By this point waitForExit has returned, so p.state is Exited(): the unit
-	// event reactor's Exited() guard will short-circuit before any read, so
-	// unloading the unit here cannot provoke a not-found GetAll feedback loop.
-	if err := os.Remove(p.unitPath()); err != nil {
-		return pState{}, err
-	}
-	if err := reloadSystemd(ctx, p.systemd); err != nil {
-		log.G(ctx).WithError(err).Error("systemd reload failed")
-	}
-
+	// The transient unit leaves nothing on disk; once stopped, systemd
+	// garbage-collects it. ResetFailedUnit forces collection of a unit that was
+	// left in the failed state.
 	if err := p.systemd.ResetFailedUnitContext(ctx, p.Name()); err != nil && !strings.Contains(err.Error(), "not loaded") {
 		// Just a debug message since this is just precautionary and the unit may not even be failed.
 		log.G(ctx).WithError(err).Debug("Failed to reset systemd unit")
@@ -223,13 +216,8 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 	p.closeTTYControl()
 
 	p.parent.execs.Delete(p.execID)
-	if err := os.Remove(p.unitPath()); err != nil {
-		log.G(ctx).WithError(err).Debug("Failed to remove exec unit")
-	}
-
-	if err := reloadSystemd(ctx, p.systemd); err != nil {
-		log.G(ctx).WithError(err).Error("systemd reload failed")
-	}
+	// The transient unit leaves nothing on disk; systemd garbage-collects it once
+	// stopped. ResetFailedUnit forces collection if it was left failed.
 	p.systemd.ResetFailedUnitContext(ctx, p.Name())
 	if err := os.RemoveAll(p.stateDir()); err != nil && !os.IsNotExist(err) {
 		log.G(ctx).WithError(err).Debug("Failed to remove exec state dir")

--- a/delete.go
+++ b/delete.go
@@ -66,7 +66,24 @@ func (s *Service) Delete(ctx context.Context, r *taskapi.DeleteRequest) (_ *task
 			return nil, err
 		}
 
+		// Deleting the container force-deletes runc, which kills any surviving
+		// exec process. Release each exec unit's reference (and clear failed
+		// state) so systemd can collect it, rather than leaking it until shim
+		// shutdown; individual exec Delete does the same. Detached from the
+		// request context because the units are untracked just below, leaving no
+		// way to retry a release the caller's cancellation skipped.
 		p.(*initProcess).execs.Each(func(ep Process) {
+			if e, ok := ep.(*execProcess); ok {
+				// Mark before releasing, so an exec Start racing this teardown
+				// either sees the flag and abandons its unit, or created it early
+				// enough that the release below covers it. Each exec gets its own
+				// budget so one slow release cannot starve the rest.
+				e.markDeleting()
+				relCtx, cancel := cleanupContext(ctx)
+				e.releaseUnit(relCtx, e.Name())
+				e.systemd.ResetFailedUnitContext(relCtx, e.Name())
+				cancel()
+			}
 			s.units.Delete(ep)
 		})
 		s.processes.Delete(path.Join(ns, r.ID))
@@ -99,13 +116,33 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 	}()
 
 	if !p.ProcessState().Exited() {
-		var st pState
-		if err := getUnitState(ctx, p.systemd, p.Name(), &st); err == nil {
+		if st, err := loadExitFromUnit(ctx, p.systemd, p.Name()); err == nil {
 			if !st.Exited() {
 				return pState{}, fmt.Errorf("container has not exited: %w, %s", errdefs.ErrFailedPrecondition, p.ProcessState())
 			}
+			// The unit exited but the shim never observed the signal -- the case the
+			// unit reference keeps recoverable. Record it: waitForExit below reads
+			// the in-memory state, so dropping this exit would leave Delete blocked
+			// on an exit that already happened and never publish its task exit.
+			p.SetState(ctx, st)
 		}
 	}
+
+	// Signal teardown before any of it runs, so a Start racing this delete can
+	// see it and not leave a unit behind (see markDeleting).
+	p.markDeleting()
+
+	// Past the precondition check we are committed to tearing the unit down, so
+	// release its reference on every exit path -- including the runc.Delete and
+	// waitForExit failures below -- otherwise systemd keeps the unit pinned until
+	// shim shutdown. Detached from the request context: a successful Delete is
+	// immediately followed by the caller untracking this process, so a release
+	// skipped because the caller canceled could never be retried.
+	defer func() {
+		relCtx, cancel := cleanupContext(ctx)
+		defer cancel()
+		p.releaseUnit(relCtx, p.Name())
+	}()
 
 	defer func() {
 		if retErr != nil {
@@ -145,9 +182,8 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 		p.systemd.KillUnitContext(ctx, unitName(p.ns, p.id, "tty"), 9)
 	}
 
-	// The transient unit leaves nothing on disk; once stopped, systemd
-	// garbage-collects it. ResetFailedUnit forces collection of a unit that was
-	// left in the failed state.
+	// Reset any failed state so systemd can collect the transient unit once its
+	// reference is released (see the deferred releaseUnit above).
 	if err := p.systemd.ResetFailedUnitContext(ctx, p.Name()); err != nil && !strings.Contains(err.Error(), "not loaded") {
 		// Just a debug message since this is just precautionary and the unit may not even be failed.
 		log.G(ctx).WithError(err).Debug("Failed to reset systemd unit")
@@ -184,6 +220,21 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 		return pState{}, fmt.Errorf("exec has not exited: %w", errdefs.ErrFailedPrecondition)
 	}
 
+	// Signal teardown before any of it runs, so a Start racing this delete can
+	// see it and not leave a unit behind (see markDeleting).
+	p.markDeleting()
+
+	// Past the precondition check we are committed to teardown; release the unit
+	// reference on every exit path -- including the waitForExit failure below --
+	// so systemd is not left pinning the unit until shim shutdown. Detached from
+	// the request context for the same reason as the init path: the exec is
+	// untracked as soon as this returns, so a skipped release is unrecoverable.
+	defer func() {
+		relCtx, cancel := cleanupContext(ctx)
+		defer cancel()
+		p.releaseUnit(relCtx, p.Name())
+	}()
+
 	ch := make(chan string, 1)
 	if _, err := p.systemd.StopUnitContext(ctx, p.Name(), "replace", ch); err != nil {
 		log.G(ctx).WithError(err).Info("Failed to stop unit")
@@ -216,8 +267,8 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 	p.closeTTYControl()
 
 	p.parent.execs.Delete(p.execID)
-	// The transient unit leaves nothing on disk; systemd garbage-collects it once
-	// stopped. ResetFailedUnit forces collection if it was left failed.
+	// Reset any failed state so systemd can collect the transient unit once its
+	// reference is released (see the deferred releaseUnit above).
 	p.systemd.ResetFailedUnitContext(ctx, p.Name())
 	if err := os.RemoveAll(p.stateDir()); err != nil && !os.IsNotExist(err) {
 		log.G(ctx).WithError(err).Debug("Failed to remove exec state dir")

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
               && !(pkgs.lib.hasSuffix ".test" base);
           };
 
-          vendorHash = "sha256-Btom6v1OCfXHudfhXLvj17GmzeEiFIUtk6FbWmDWKnA=";
+          vendorHash = "sha256-7V9DnwVeUFqrpwpcNMYq/copyRXBWZHGZYBDEEibE0w=";
 
           subPackages = [
             "."

--- a/main.go
+++ b/main.go
@@ -147,25 +147,6 @@ func main() {
 
 	traceCfg := TraceFlags(flags)
 
-	doMount := func(ctx context.Context, p string) error {
-		cfgData, err := os.ReadFile(p)
-		if err != nil {
-			return err
-		}
-
-		var cfg taskapi.CreateTaskRequest
-		if err := proto.Unmarshal(cfgData, &cfg); err != nil {
-			return fmt.Errorf("error unmarshalling task create: %w", err)
-		}
-
-		target, err := mountFS(cfg.Rootfs, cfg.Bundle)
-		if err != nil {
-			return err
-		}
-		fmt.Fprintln(os.Stderr, "Mounted rootfs to", target)
-		return err
-	}
-
 	containerdConfigPath := filepath.Join(defaults.DefaultConfigDir, "config.toml")
 	commands := map[string]func(context.Context) error{
 		"install": func(ctx context.Context) error {
@@ -258,7 +239,7 @@ func main() {
 			if flags.NArg() != 1 {
 				return errors.New("mount requires exactly one argument")
 			}
-			return doMount(ctx, flag.Arg(0))
+			return mountRootfs(flag.Arg(0))
 		},
 		"unmount": func(ctx context.Context) error {
 			return mount.UnmountAll(flags.Arg(0), 0)
@@ -268,7 +249,7 @@ func main() {
 			ctx = WithShimLog(ctx, OpenShimLog(ctx, bundle))
 
 			if mountCfg != "" {
-				if err := doMount(ctx, mountCfg); err != nil {
+				if err := mountRootfs(mountCfg); err != nil {
 					return err
 				}
 			}

--- a/manager.go
+++ b/manager.go
@@ -67,7 +67,6 @@ func New(ctx context.Context, cfg Config) (*Service, error) {
 		conn:    conn,
 		runcBin: runcPath,
 		exe:     exe,
-		unitDir: systemUnitDir,
 	})
 	if err != nil {
 		conn.Close()
@@ -81,7 +80,6 @@ type serviceConfig struct {
 	conn    *systemd.Conn
 	runcBin string
 	exe     string
-	unitDir string
 }
 
 func newServiceWithConfig(ctx context.Context, cfg serviceConfig) (*Service, error) {
@@ -100,7 +98,6 @@ func newServiceWithConfig(ctx context.Context, cfg serviceConfig) (*Service, err
 		conn:           cfg.conn,
 		exe:            cfg.exe,
 		root:           cfg.Root,
-		unitDir:        cfg.unitDir,
 		noNewNamespace: cfg.NoNewNamespace,
 		publisher:      cfg.Publisher,
 		events:         make(chan eventEnvelope, 128),
@@ -118,7 +115,6 @@ type Service struct {
 	runcBin        string
 	debug          bool
 	root           string
-	unitDir        string
 	noNewNamespace bool
 	publisher      events.Publisher
 	events         chan eventEnvelope

--- a/manager.go
+++ b/manager.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containerd/typeurl/v2"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/cpuguy83/containerd-shim-systemd-v1/options"
+	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel/attribute"
@@ -37,6 +38,20 @@ const systemUnitDir = "/run/systemd/system"
 var (
 	timeZero = time.UnixMicro(0)
 )
+
+// cleanupTimeout bounds teardown work started after a request already failed.
+const cleanupTimeout = 30 * time.Second
+
+// cleanupContext returns a context for teardown that must run even when the
+// request which triggered it was canceled -- a canceled request is itself a
+// common reason to be cleaning up, and teardown is all D-Bus and runc calls that
+// would fail instantly on a dead context, leaving units running and their
+// references stranded (a stranded reference keeps the unit loaded, which blocks
+// reusing its id). It keeps the request's log and trace values, drops only its
+// cancellation, and bounds the result so teardown cannot hang.
+func cleanupContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), cleanupTimeout)
+}
 
 type Config struct {
 	Root           string
@@ -62,14 +77,31 @@ func New(ctx context.Context, cfg Config) (*Service, error) {
 		exe = os.Args[0]
 	}
 
+	// A single message-bus connection, separate from the private method
+	// connection, used only to pin transient units: they are started with
+	// AddRef=true so they survive collection after a clean exit. Best-effort --
+	// if the message bus is unavailable the shim still runs, but a unit collected
+	// after a missed exit signal could lose its exit code. Shared by every
+	// process.
+	pinConn, pinRef, err := newPinConnection(ctx)
+	if err != nil {
+		log.G(ctx).WithError(err).Warn("No D-Bus message bus for unit references; transient units are not pinned")
+		pinConn, pinRef = nil, nil
+	}
+
 	s, err := newServiceWithConfig(ctx, serviceConfig{
 		Config:  cfg,
 		conn:    conn,
+		pinConn: pinConn,
+		pinRef:  pinRef,
 		runcBin: runcPath,
 		exe:     exe,
 	})
 	if err != nil {
 		conn.Close()
+		if pinConn != nil {
+			pinConn.Close()
+		}
 		return nil, err
 	}
 	return s, nil
@@ -78,6 +110,8 @@ func New(ctx context.Context, cfg Config) (*Service, error) {
 type serviceConfig struct {
 	Config
 	conn    *systemd.Conn
+	pinConn *systemd.Conn
+	pinRef  *dbus.Conn
 	runcBin string
 	exe     string
 }
@@ -96,6 +130,8 @@ func newServiceWithConfig(ctx context.Context, cfg serviceConfig) (*Service, err
 	debug := logrus.GetLevel() >= logrus.DebugLevel
 	return &Service{
 		conn:           cfg.conn,
+		pinConn:        cfg.pinConn,
+		pinRef:         cfg.pinRef,
 		exe:            cfg.exe,
 		root:           cfg.Root,
 		noNewNamespace: cfg.NoNewNamespace,
@@ -112,6 +148,8 @@ func newServiceWithConfig(ctx context.Context, cfg serviceConfig) (*Service, err
 
 type Service struct {
 	conn           *systemd.Conn
+	pinConn        *systemd.Conn
+	pinRef         *dbus.Conn
 	runcBin        string
 	debug          bool
 	root           string
@@ -145,6 +183,11 @@ func unitName(ns, id, mod string) string {
 func (s *Service) Close() {
 	s.conn.Unsubscribe()
 	s.conn.Close()
+	if s.pinConn != nil {
+		// Closes both the go-systemd Conn and the underlying method connection
+		// pinRef wraps.
+		s.pinConn.Close()
+	}
 	close(s.events)
 	<-s.waitEvents
 }

--- a/metrics.go
+++ b/metrics.go
@@ -1,11 +1,7 @@
 package main
 
 import (
-	"context"
 	"expvar"
-	"time"
-
-	"github.com/coreos/go-systemd/v22/dbus"
 )
 
 // State-source metric keys. These count how the shim answers process
@@ -14,10 +10,11 @@ import (
 // file. The reactor-hit vs getall-fallback ratio is the event reactor's
 // effective hit rate; on-disk reads are the other fallback source.
 //
-// daemon_reload_* measure time spent in systemd `daemon-reload` (Reload over
-// D-Bus), which the shim issues on every create/delete because it writes unit
-// files to disk. daemon-reload re-parses every unit, so its cost grows with the
-// number of units on the host — a prime suspect for create/delete latency.
+// daemon_reload_* formerly measured time spent in systemd `daemon-reload`, which
+// the shim issued on every create/delete because it wrote unit files to disk.
+// The shim now creates units transiently (StartTransientUnit), so no reload is
+// issued and these counters stay 0. They remain published so the benchmark
+// schema is stable and a run visibly shows reloads eliminated.
 const (
 	metricReactorHits       = "exitstate_reactor_hits"
 	metricGetAllFallbacks   = "exitstate_getall_fallbacks"
@@ -48,15 +45,3 @@ var stateMetrics = func() *expvar.Map {
 
 // countState increments one of the state-source counters above.
 func countState(key string) { stateMetrics.Add(key, 1) }
-
-// reloadSystemd issues a systemd daemon-reload and records how long it took.
-// The count and cumulative duration are exposed via expvar so the benchmark can
-// attribute create/delete latency to reload cost. Reloads are timed even on
-// error, since the time was still spent.
-func reloadSystemd(ctx context.Context, conn *dbus.Conn) error {
-	start := time.Now()
-	err := conn.ReloadContext(ctx)
-	stateMetrics.Add(metricDaemonReloadCount, 1)
-	stateMetrics.Add(metricDaemonReloadNanos, int64(time.Since(start)))
-	return err
-}

--- a/metrics.go
+++ b/metrics.go
@@ -9,19 +9,11 @@ import (
 // versus falling back to a systemd GetAll property read or an on-disk exit
 // file. The reactor-hit vs getall-fallback ratio is the event reactor's
 // effective hit rate; on-disk reads are the other fallback source.
-//
-// daemon_reload_* formerly measured time spent in systemd `daemon-reload`, which
-// the shim issued on every create/delete because it wrote unit files to disk.
-// The shim now creates units transiently (StartTransientUnit), so no reload is
-// issued and these counters stay 0. They remain published so the benchmark
-// schema is stable and a run visibly shows reloads eliminated.
 const (
-	metricReactorHits       = "exitstate_reactor_hits"
-	metricGetAllFallbacks   = "exitstate_getall_fallbacks"
-	metricOnDiskReads       = "state_ondisk_reads"
-	metricGetUnitCalls      = "getunitstate_calls"
-	metricDaemonReloadCount = "daemon_reload_count"
-	metricDaemonReloadNanos = "daemon_reload_nanos"
+	metricReactorHits     = "exitstate_reactor_hits"
+	metricGetAllFallbacks = "exitstate_getall_fallbacks"
+	metricOnDiskReads     = "state_ondisk_reads"
+	metricGetUnitCalls    = "getunitstate_calls"
 )
 
 // stateMetrics is published at /debug/vars (wired in serve()). Counters are
@@ -35,8 +27,6 @@ var stateMetrics = func() *expvar.Map {
 		metricGetAllFallbacks,
 		metricOnDiskReads,
 		metricGetUnitCalls,
-		metricDaemonReloadCount,
-		metricDaemonReloadNanos,
 	} {
 		m.Add(k, 0)
 	}

--- a/mount.go
+++ b/mount.go
@@ -5,9 +5,32 @@ import (
 	"os"
 	"path/filepath"
 
+	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/v2/core/mount"
+	"google.golang.org/protobuf/proto"
 )
+
+// mountRootfs reads a marshaled CreateTaskRequest from configPath (written by
+// initProcess.writeMountConfig) and mounts its rootfs onto <bundle>/rootfs. It
+// backs both the `mount` re-exec (ExecStartPre in the no-new-namespace path) and
+// the --mounts create path (PrivateMounts).
+func mountRootfs(configPath string) error {
+	cfgData, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var cfg taskapi.CreateTaskRequest
+	if err := proto.Unmarshal(cfgData, &cfg); err != nil {
+		return fmt.Errorf("error unmarshalling task create: %w", err)
+	}
+
+	if _, err := mountFS(cfg.Rootfs, cfg.Bundle); err != nil {
+		return err
+	}
+	return nil
+}
 
 func mountFS(tmounts []*types.Mount, bundle string) (string, error) {
 	var mounts []mount.Mount

--- a/mount_test.go
+++ b/mount_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/go-runc"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+)
+
+// A non-empty Rootfs selects one of two mount strategies, both expressed as
+// transient unit properties. This proves each builds the right properties
+// without a live bus: the no-new-namespace path uses ExecStartPre/ExecStopPost
+// re-execs, and the default path uses PrivateMounts plus a --mounts create. The
+// no-new-namespace runtime is additionally exercised end to end by
+// TestServiceTaskRootfsMountAgainstSystemd.
+func TestInitProcessRootfsMountProperties(t *testing.T) {
+	newProc := func(noNewNamespace bool) *initProcess {
+		p, _ := newTestInitProcess("mount-props")
+		p.Bundle = "/bundle"
+		p.root = "/root"
+		p.exe = "/shim"
+		p.runc = &runc.Runc{Command: "/runc", Root: "/runc/root"}
+		p.Rootfs = []*types.Mount{{Type: "bind", Source: "/src", Options: []string{"rbind"}}}
+		p.noNewNamespace = noNewNamespace
+		return p
+	}
+
+	t.Run("the no-new-namespace path mounts via ExecStartPre and unmounts via ExecStopPost", func(t *testing.T) {
+		props, err := newProc(true).startProperties([]string{"create"})
+		if err != nil {
+			t.Fatalf("startProperties: %v", err)
+		}
+		if has(props, "PrivateMounts") {
+			t.Fatal("no-new-namespace unit should not set PrivateMounts")
+		}
+		if pre := strings.Join(execArgs(t, props, "ExecStartPre"), " "); !strings.Contains(pre, "mount") {
+			t.Fatalf("ExecStartPre = %q, want a mount command", pre)
+		}
+		if post := strings.Join(execArgs(t, props, "ExecStopPost"), " "); !strings.Contains(post, "unmount") {
+			t.Fatalf("ExecStopPost = %q, want an unmount command", post)
+		}
+	})
+
+	t.Run("the default path mounts via PrivateMounts and a --mounts create", func(t *testing.T) {
+		props, err := newProc(false).startProperties([]string{"create"})
+		if err != nil {
+			t.Fatalf("startProperties: %v", err)
+		}
+		if !has(props, "PrivateMounts") {
+			t.Fatal("default unit should set PrivateMounts")
+		}
+		if has(props, "ExecStartPre") {
+			t.Fatal("default unit should not set ExecStartPre")
+		}
+		if start := strings.Join(execArgs(t, props, "ExecStart"), " "); !strings.Contains(start, "--mounts=") {
+			t.Fatalf("ExecStart = %q, want a --mounts create", start)
+		}
+	})
+}
+
+func has(props []systemd.Property, name string) bool {
+	for _, p := range props {
+		if p.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// execArgs returns the argv of the named Exec* transient property.
+func execArgs(t *testing.T, props []systemd.Property, name string) []string {
+	t.Helper()
+	for _, p := range props {
+		if p.Name != name {
+			continue
+		}
+		cmds, ok := p.Value.Value().([]execCommand)
+		if !ok || len(cmds) == 0 {
+			t.Fatalf("%s value = %T, want a non-empty []execCommand", name, p.Value.Value())
+		}
+		return cmds[0].Args
+	}
+	t.Fatalf("no %s property found", name)
+	return nil
+}

--- a/process.go
+++ b/process.go
@@ -21,6 +21,7 @@ import (
 	"github.com/containerd/log"
 	"github.com/containerd/typeurl/v2"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -207,12 +208,22 @@ type process struct {
 	systemd *systemd.Conn
 	runc    *runc.Runc
 
+	// pinConn starts the transient unit with AddRef=true so systemd will not
+	// garbage-collect it after a clean exit, keeping its terminal state queryable
+	// over D-Bus. pinRef is the same message-bus connection's raw method handle,
+	// used to UnrefUnit at Delete. Both are nil when no message bus is available,
+	// in which case the unit starts on the private connection unpinned. They are
+	// shared across all processes.
+	pinConn *systemd.Conn
+	pinRef  *dbus.Conn
+
 	ttyControl *ttyControlClient
 
 	mu           sync.Mutex
 	cond         *sync.Cond
 	state        pState
 	deleted      bool
+	deleting     bool
 	exitNotified bool
 	started      bool
 
@@ -314,6 +325,27 @@ func (p *process) markStarted() {
 	p.mu.Lock()
 	p.started = true
 	p.mu.Unlock()
+}
+
+// markDeleting records that teardown has begun, before any of it runs. A start
+// racing that teardown checks this once its unit exists (see isDeleting): the
+// two orderings are then both safe -- either the unit already existed and
+// teardown tears it down, or it did not and the starter sees the flag and
+// abandons it. Without that, a delete could untrack the process just before a
+// start created its unit, stranding a running, referenced unit that nothing
+// would ever release. It is distinct from deleted, which is set only once
+// teardown finishes because waitForExit uses it to stop waiting.
+func (p *process) markDeleting() {
+	p.mu.Lock()
+	p.deleting = true
+	p.mu.Unlock()
+}
+
+func (p *process) isDeleting() bool {
+	p.mu.Lock()
+	deleting := p.deleting
+	p.mu.Unlock()
+	return deleting
 }
 
 func (p *process) hasStarted() bool {

--- a/process.go
+++ b/process.go
@@ -185,10 +185,9 @@ func (c CreateOptions) RestoreArgs() []string {
 }
 
 type process struct {
-	ns      string
-	id      string
-	root    string
-	unitDir string
+	ns   string
+	id   string
+	root string
 
 	// pathName is the unit's systemd-escaped D-Bus object-path base, computed
 	// once at creation. The event reactor matches incoming signals against it,
@@ -339,14 +338,6 @@ func (p *process) PathName() string {
 	return p.pathName
 }
 
-func (p *initProcess) unitPath() string {
-	return filepath.Join(p.unitDir, p.Name())
-}
-
-func (p *execProcess) unitPath() string {
-	return filepath.Join(p.unitDir, p.Name())
-}
-
 func (p *process) Pid() uint32 {
 	p.mu.Lock()
 	pid := p.state.Pid
@@ -405,6 +396,11 @@ type initProcess struct {
 
 	Bundle string
 	Rootfs []*types.Mount
+
+	// unitProps holds the transient-unit properties computed by Create (or
+	// createRestore) and consumed by startUnit. It bridges the two because a
+	// checkpoint restore builds them at Create but starts the unit later.
+	unitProps []systemd.Property
 
 	checkpoint       string
 	parentCheckpoint string

--- a/runc_stub_test.go
+++ b/runc_stub_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
@@ -25,6 +26,10 @@ const (
 	runcStubExitCodeAnnotation  = "io.containerd.systemd.test.exit-code"
 	runcStubExitDelayAnnotation = "io.containerd.systemd.test.exit-delay"
 	runcStubFailpointAnnotation = "io.containerd.systemd.test.failpoint"
+	// runcStubRootfsMarkerAnnotation names a file the managed process must find
+	// under <bundle>/rootfs, proving the container's rootfs was mounted (in either
+	// the host namespace or the unit's private mount namespace).
+	runcStubRootfsMarkerAnnotation = "io.containerd.systemd.test.rootfs-marker"
 
 	runcStubExitCodeEnv         = "RUNC_STUB_EXIT_CODE"
 	runcStubExitDelayEnv        = "RUNC_STUB_EXIT_DELAY"
@@ -33,10 +38,15 @@ const (
 	runcStubWaitForReleaseEnv   = "RUNC_STUB_WAIT_FOR_RELEASE"
 
 	runcStubKillAllMarker = "kill-all"
+	// runcStubCheckpointImage is a file the test writes into a checkpoint dir;
+	// `runc restore` must be handed that dir via --image-path, proving the shim
+	// took the restore path with the right checkpoint rather than a plain create.
+	runcStubCheckpointImage = "checkpoint.img"
 
 	runcStubCreateFailure = 42
 	runcStubStartFailure  = 43
 	runcStubExecFailure   = 45
+	runcStubRootfsMissing = 66
 )
 
 type runcStubConfig struct {
@@ -48,6 +58,7 @@ type runcStubConfig struct {
 	ExitBeforeDetach bool          `json:"exitBeforeDetach,omitempty"`
 	WaitForRelease   bool          `json:"waitForRelease,omitempty"`
 	ParentPID        int           `json:"parentPid,omitempty"`
+	RootfsCheck      string        `json:"rootfsCheck,omitempty"`
 }
 
 func TestMain(m *testing.M) {
@@ -68,10 +79,22 @@ func TestMain(m *testing.M) {
 }
 
 func runShimCreateHelper() error {
+	// The no-new-namespace rootfs path drives ExecStartPre/ExecStopPost, which
+	// re-exec the shim as `<exe> mount <cfg>` and `<exe> unmount <rootfs>`.
+	if len(os.Args) >= 3 {
+		switch os.Args[1] {
+		case "mount":
+			return mountRootfs(os.Args[2])
+		case "unmount":
+			return mount.UnmountAll(os.Args[2], 0)
+		}
+	}
+
 	flags := flag.NewFlagSet(shimCreateHelperName, flag.ContinueOnError)
 	flags.Bool("debug", false, "")
 	bundle := flags.String("bundle", "", "")
 	tty := flags.Bool("tty", false, "")
+	mounts := flags.String("mounts", "", "")
 	if err := flags.Parse(os.Args[1:]); err != nil {
 		return err
 	}
@@ -80,7 +103,13 @@ func runShimCreateHelper() error {
 	if len(args) < 2 || args[0] != "create" {
 		return fmt.Errorf("invalid shim helper arguments: %q", os.Args[1:])
 	}
-	return createCmd(context.Background(), *bundle, args[1:], *tty, false)
+	// The PrivateMounts path mounts the rootfs in the create re-exec before runc.
+	if *mounts != "" {
+		if err := mountRootfs(*mounts); err != nil {
+			return err
+		}
+	}
+	return createCmd(context.Background(), *bundle, args[1:], *tty, *mounts != "")
 }
 
 func runRuncStub() int {
@@ -99,6 +128,8 @@ func runRuncStub() int {
 	switch command {
 	case "create":
 		code, err = runRuncStubCreate(root, args)
+	case "restore":
+		code, err = runRuncStubRestore(root, args)
 	case "exec":
 		code, err = runRuncStubExec(args)
 	case "start":
@@ -201,6 +232,42 @@ func runRuncStubCreate(root string, args []string) (int, error) {
 		return runcStubCreateFailure, fmt.Errorf("runc create failpoint")
 	}
 
+	stateDir := filepath.Join(root, id)
+	if err := os.MkdirAll(stateDir, 0700); err != nil {
+		return 125, err
+	}
+	return startRuncStubProcess(stateDir, pidFile, cfg)
+}
+
+// runRuncStubRestore models `runc restore`: it starts the restored container
+// immediately (there is no separate start) and reports its pid. restore carries
+// no --pid-file flag, so the pid path comes from the PIDFILE the unit exports.
+func runRuncStubRestore(root string, args []string) (int, error) {
+	bundle, err := commandOption(args, "--bundle")
+	if err != nil {
+		return 125, err
+	}
+	imagePath, err := commandOption(args, "--image-path")
+	if err != nil {
+		return 125, err
+	}
+	// restore must be handed the checkpoint the task was created with.
+	if _, err := os.Stat(filepath.Join(imagePath, runcStubCheckpointImage)); err != nil {
+		return 125, fmt.Errorf("restore image-path %q has no checkpoint: %w", imagePath, err)
+	}
+	id, err := commandID(args)
+	if err != nil {
+		return 125, err
+	}
+	pidFile := os.Getenv("PIDFILE")
+	if pidFile == "" {
+		return 125, fmt.Errorf("runc restore stub: no PIDFILE in environment")
+	}
+	cfg, err := readRuncStubBundleConfig(bundle)
+	if err != nil {
+		return 125, err
+	}
+	cfg.StartImmediately = true
 	stateDir := filepath.Join(root, id)
 	if err := os.MkdirAll(stateDir, 0700); err != nil {
 		return 125, err
@@ -339,6 +406,16 @@ func runManagedProcess() int {
 		return 125
 	}
 
+	// If the container declares a rootfs marker, the shim must have mounted the
+	// rootfs (host-namespace ExecStartPre or private-namespace --mounts) before
+	// the container runs.
+	if cfg.RootfsCheck != "" {
+		if _, err := os.Stat(cfg.RootfsCheck); err != nil {
+			fmt.Fprintln(os.Stderr, "rootfs marker missing:", err)
+			return runcStubRootfsMissing
+		}
+	}
+
 	if !cfg.StartImmediately {
 		started := filepath.Join(stateDir, "started")
 		for {
@@ -382,6 +459,9 @@ func readRuncStubBundleConfig(bundle string) (runcStubConfig, error) {
 	}
 	if err := setRuncStubExitDelay(&cfg, spec.Annotations[runcStubExitDelayAnnotation]); err != nil {
 		return runcStubConfig{}, err
+	}
+	if marker := spec.Annotations[runcStubRootfsMarkerAnnotation]; marker != "" {
+		cfg.RootfsCheck = filepath.Join(bundle, "rootfs", marker)
 	}
 	return cfg, nil
 }

--- a/runc_stub_test.go
+++ b/runc_stub_test.go
@@ -289,9 +289,14 @@ func runRuncStubDelete(root string, args []string) (int, error) {
 		return 125, err
 	}
 	stateDir := filepath.Join(root, id)
+	// Real runc removes the container's state only on a successful delete, and
+	// preserves it on failure. Mirror that: a reused container id then starts from
+	// a clean state directory instead of inheriting the previous run's "started"
+	// marker, while a failed delete keeps state so lifecycle tests can observe it.
 	pidData, err := os.ReadFile(filepath.Join(stateDir, "pid"))
 	if err != nil {
 		if os.IsNotExist(err) {
+			os.RemoveAll(stateDir)
 			return 0, nil
 		}
 		return 125, err
@@ -303,6 +308,7 @@ func runRuncStubDelete(root string, args []string) (int, error) {
 	cmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
 	if err != nil {
 		if os.IsNotExist(err) {
+			os.RemoveAll(stateDir)
 			return 0, nil
 		}
 		return 125, err
@@ -317,6 +323,7 @@ func runRuncStubDelete(root string, args []string) (int, error) {
 	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
 		return 125, err
 	}
+	os.RemoveAll(stateDir)
 	return 0, nil
 }
 

--- a/service_integration_test.go
+++ b/service_integration_test.go
@@ -14,8 +14,10 @@ import (
 
 	eventsapi "github.com/containerd/containerd/api/events"
 	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
+	"github.com/containerd/containerd/api/types"
 	v2runcopts "github.com/containerd/containerd/api/types/runc/options"
 	tasktypes "github.com/containerd/containerd/api/types/task"
+	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/typeurl/v2"
 	systemd "github.com/coreos/go-systemd/v22/dbus"
@@ -420,6 +422,12 @@ func TestServiceExecIDReuseAgainstSystemd(t *testing.T) {
 	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
 		t.Fatalf("start parent task: %v", err)
 	}
+	// Tear the long-lived parent down on every exit path -- including a failed
+	// subtest that aborts before the loop finishes -- so it never lingers.
+	t.Cleanup(func() {
+		_, _ = h.service.Kill(ctx, &taskapi.KillRequest{ID: req.ID, Signal: uint32(unix.SIGKILL), All: true})
+		_, _ = h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID})
+	})
 
 	const execID = "reused-exec"
 	runs := []struct {
@@ -438,17 +446,127 @@ func TestServiceExecIDReuseAgainstSystemd(t *testing.T) {
 			assertExecRunAndExit(t, h, ctx, req, execID, execUnit, tc.exitCode)
 		})
 	}
+}
 
-	if _, err := h.service.Kill(ctx, &taskapi.KillRequest{ID: req.ID, Signal: uint32(unix.SIGKILL)}); err != nil {
-		t.Fatalf("kill parent task: %v", err)
+// A checkpoint restore is not a from-scratch create: Create records the restore
+// command and defers the runc invocation to Start, which runs
+// `runc restore --image-path=<checkpoint>`. This drives that through the public
+// task API and proves it is a restore -- Create returns no pid (a create would
+// return the runc pid), and the runc stub fails unless it is handed the
+// checkpoint image at --image-path.
+func TestServiceTaskRestoreAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	ctx, req, _ := h.task(t, "restore-target", runcStubConfig{ExitDelay: 100 * time.Millisecond})
+
+	checkpoint := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkpoint, runcStubCheckpointImage), nil, 0600); err != nil {
+		t.Fatalf("write checkpoint image: %v", err)
 	}
+	req.Checkpoint = checkpoint
+
+	created, err := h.service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("create restore task: %v", err)
+	}
+	// Restore defers its runc invocation to Start, so Create returns no pid; a
+	// from-scratch create would return the runc pid here.
+	if created.Pid != 0 {
+		t.Fatalf("restore create returned pid %d, want 0 (restore defers to start)", created.Pid)
+	}
+
+	started, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("start restore task: %v", err)
+	}
+	if started.Pid == 0 {
+		t.Fatal("restore start returned a zero pid")
+	}
+
 	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
-	if _, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID}); err != nil {
-		t.Fatalf("wait for parent task: %v", err)
+	waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("wait for restored task: %v", err)
 	}
+	if waited.ExitStatus != 0 {
+		t.Fatalf("wait exit status = %d, want 0", waited.ExitStatus)
+	}
+
 	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
-		t.Fatalf("delete parent task: %v", err)
+		t.Fatalf("delete restored task: %v", err)
+	}
+}
+
+// TestServiceTaskRootfsMountAgainstSystemd exercises the no-new-namespace rootfs
+// path end to end: a non-empty Rootfs with "shared" propagation makes the shim
+// mount the rootfs via an ExecStartPre re-exec (in the host namespace) and
+// unmount it via ExecStopPost. Both are hand-built transient exec tuples. The
+// mount is checked from the host and from inside the container (a marker file),
+// and the unmount is checked after delete. (The PrivateMounts variant's property
+// construction is covered by TestInitProcessRootfsMountProperties; its runtime
+// needs cross-namespace runc state the in-process stub cannot model.)
+func TestServiceTaskRootfsMountAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	requireBindMount(t)
+
+	const marker = "mounted"
+	src := t.TempDir()
+	if err := os.WriteFile(filepath.Join(src, marker), nil, 0600); err != nil {
+		t.Fatalf("write rootfs marker: %v", err)
+	}
+
+	ctx, req, _ := h.task(t, "rootfs-mount", runcStubConfig{ExitDelay: 100 * time.Millisecond}, func(s *specs.Spec) {
+		s.Annotations[runcStubRootfsMarkerAnnotation] = marker
+		s.Linux.RootfsPropagation = "shared" // selects the no-new-namespace path
+	})
+	req.Rootfs = []*types.Mount{{Type: "bind", Source: src, Options: []string{"rbind"}}}
+	rootfs := filepath.Join(req.Bundle, "rootfs")
+
+	if _, err := h.service.Create(ctx, req); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	// ExecStartPre mounted the rootfs in the host namespace.
+	if _, err := os.Stat(filepath.Join(rootfs, marker)); err != nil {
+		t.Fatalf("rootfs not mounted in host namespace: %v", err)
+	}
+
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	// A clean zero exit proves the container saw its mounted rootfs; a missing
+	// mount would have exited runcStubRootfsMissing instead.
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("wait for task: %v", err)
+	}
+	if waited.ExitStatus != 0 {
+		t.Fatalf("task exit status = %d, want 0 (container saw the rootfs marker)", waited.ExitStatus)
+	}
+
+	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+	// ExecStopPost unmounted the rootfs, so the host no longer sees it.
+	if _, err := os.Stat(filepath.Join(rootfs, marker)); !os.IsNotExist(err) {
+		t.Fatalf("rootfs still mounted after delete: %v", err)
+	}
+}
+
+// requireBindMount skips the test when this environment cannot bind mount, e.g.
+// a user systemd manager whose units run without CAP_SYS_ADMIN. The shim's
+// rootfs mount runs in a systemd unit with the same privileges as this process,
+// so probing here is representative.
+func requireBindMount(t *testing.T) {
+	t.Helper()
+	src, dst := t.TempDir(), t.TempDir()
+	if err := mount.All([]mount.Mount{{Type: "bind", Source: src, Options: []string{"rbind"}}}, dst); err != nil {
+		t.Skipf("cannot bind mount (need CAP_SYS_ADMIN): %v", err)
+	}
+	if err := mount.UnmountAll(dst, 0); err != nil {
+		t.Logf("unmount probe mount %s: %v", dst, err)
 	}
 }
 
@@ -522,7 +640,7 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 	}
 }
 
-func (h *serviceIntegrationHarness) task(t *testing.T, id string, cfg runcStubConfig) (context.Context, *taskapi.CreateTaskRequest, string) {
+func (h *serviceIntegrationHarness) task(t *testing.T, id string, cfg runcStubConfig, specOpts ...func(*specs.Spec)) (context.Context, *taskapi.CreateTaskRequest, string) {
 	t.Helper()
 	bundle := t.TempDir()
 	spec := specs.Spec{
@@ -535,6 +653,9 @@ func (h *serviceIntegrationHarness) task(t *testing.T, id string, cfg runcStubCo
 			runcStubExitDelayAnnotation: cfg.ExitDelay.String(),
 			runcStubFailpointAnnotation: cfg.Failpoint,
 		},
+	}
+	for _, o := range specOpts {
+		o(&spec)
 	}
 	data, err := json.Marshal(spec)
 	if err != nil {

--- a/service_integration_test.go
+++ b/service_integration_test.go
@@ -174,7 +174,7 @@ func TestServiceRuntimeOptionsAgainstSystemd(t *testing.T) {
 			if _, err := h.service.Create(ctx, req); err != nil {
 				t.Fatalf("create task: %v", err)
 			}
-			assertUnitWorkingDirectory(t, filepath.Join(h.unitDir, taskUnit), req.Bundle)
+			assertUnitWorkingDirectory(t, h.conn, taskUnit, req.Bundle)
 			if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
 				t.Fatalf("start task: %v", err)
 			}
@@ -184,7 +184,7 @@ func TestServiceRuntimeOptionsAgainstSystemd(t *testing.T) {
 			if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID, ExecID: execID}); err != nil {
 				t.Fatalf("start exec: %v", err)
 			}
-			assertUnitWorkingDirectory(t, filepath.Join(h.unitDir, execUnit), req.Bundle)
+			assertUnitWorkingDirectory(t, h.conn, execUnit, req.Bundle)
 
 			execWaitCtx, cancelExecWait := context.WithTimeout(ctx, 10*time.Second)
 			defer cancelExecWait()
@@ -230,16 +230,22 @@ func TestServiceRuntimeOptionsAgainstSystemd(t *testing.T) {
 	})
 }
 
-func assertUnitWorkingDirectory(t *testing.T, unitPath, workingDirectory string) {
+func assertUnitWorkingDirectory(t *testing.T, conn *systemd.Conn, unit, workingDirectory string) {
 	t.Helper()
 
-	data, err := os.ReadFile(unitPath)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	prop, err := conn.GetUnitTypePropertyContext(ctx, unit, "Service", "WorkingDirectory")
 	if err != nil {
-		t.Fatalf("read unit file %s: %v", unitPath, err)
+		t.Fatalf("get WorkingDirectory for %s: %v", unit, err)
 	}
-	want := "WorkingDirectory=" + workingDirectory
-	if !strings.Contains(string(data), want) {
-		t.Fatalf("unit file %s does not contain %q:\n%s", unitPath, want, data)
+	got, ok := prop.Value.Value().(string)
+	if !ok {
+		t.Fatalf("WorkingDirectory for %s is %T, want string", unit, prop.Value.Value())
+	}
+	if got != workingDirectory {
+		t.Fatalf("unit %s WorkingDirectory = %q, want %q", unit, got, workingDirectory)
 	}
 }
 
@@ -374,6 +380,78 @@ func TestServiceExecLifecycleAgainstSystemd(t *testing.T) {
 	}
 }
 
+// Transient units are registered under the task's unit name, so a task id can
+// only be recreated once the shim's Delete has released the previous unit. These
+// tests reuse a single id across successive runs -- normal, non-zero, and fast
+// (immediate) exits -- driving each run's Delete before the next Create. h.task
+// registers its unit cleanup against the enclosing test, not each subtest, so it
+// is the shim's own Delete that must free the name between runs.
+func TestServiceTaskIDReuseAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	const id = "reused-task"
+
+	runs := []struct {
+		name     string
+		cfg      runcStubConfig
+		exitCode uint32
+	}{
+		{"a successful zero-exit run reuses the task id", runcStubConfig{ExitDelay: 100 * time.Millisecond}, 0},
+		{"a non-zero exit run reuses the task id", runcStubConfig{ExitCode: 9, ExitDelay: 100 * time.Millisecond}, 9},
+		{"a fast zero-exit run reuses the task id", runcStubConfig{}, 0},
+		{"a fast non-zero exit run reuses the task id", runcStubConfig{ExitCode: 11}, 11},
+	}
+	for _, tc := range runs {
+		ctx, req, unit := h.task(t, id, tc.cfg)
+		t.Run(tc.name, func(t *testing.T) {
+			assertTaskRunAndExit(t, h, ctx, req, unit, tc.exitCode)
+		})
+	}
+}
+
+// TestServiceExecIDReuseAgainstSystemd is the exec analogue: a single exec id is
+// run repeatedly against one long-lived parent, so the shim's exec Delete must
+// release the exec's transient unit before it can be recreated.
+func TestServiceExecIDReuseAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	ctx, req, _ := h.task(t, "exec-reuse-parent", runcStubConfig{ExitDelay: 30 * time.Second})
+	if _, err := h.service.Create(ctx, req); err != nil {
+		t.Fatalf("create parent task: %v", err)
+	}
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+		t.Fatalf("start parent task: %v", err)
+	}
+
+	const execID = "reused-exec"
+	runs := []struct {
+		name     string
+		cfg      runcStubConfig
+		exitCode uint32
+	}{
+		{"a successful zero-exit run reuses the exec id", runcStubConfig{ExitDelay: 100 * time.Millisecond}, 0},
+		{"a non-zero exit run reuses the exec id", runcStubConfig{ExitCode: 17, ExitDelay: 100 * time.Millisecond}, 17},
+		{"a fast zero-exit run reuses the exec id", runcStubConfig{ExitBeforeDetach: true}, 0},
+		{"a fast non-zero exit run reuses the exec id", runcStubConfig{ExitCode: 19, ExitBeforeDetach: true}, 19},
+	}
+	for _, tc := range runs {
+		execUnit := h.exec(t, ctx, req, execID, tc.cfg)
+		t.Run(tc.name, func(t *testing.T) {
+			assertExecRunAndExit(t, h, ctx, req, execID, execUnit, tc.exitCode)
+		})
+	}
+
+	if _, err := h.service.Kill(ctx, &taskapi.KillRequest{ID: req.ID, Signal: uint32(unix.SIGKILL)}); err != nil {
+		t.Fatalf("kill parent task: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID}); err != nil {
+		t.Fatalf("wait for parent task: %v", err)
+	}
+	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
+		t.Fatalf("delete parent task: %v", err)
+	}
+}
+
 type serviceIntegrationHarness struct {
 	service   *Service
 	conn      *systemd.Conn
@@ -406,7 +484,6 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 		conn:    conn,
 		runcBin: filepath.Join(helperDir, runcStubHelperName),
 		exe:     filepath.Join(helperDir, shimCreateHelperName),
-		unitDir: unitDir,
 	})
 	if err != nil {
 		conn.Close()
@@ -646,4 +723,91 @@ func assertNoProcessExit(t *testing.T, events <-chan eventEnvelope, containerID,
 			return
 		}
 	}
+}
+
+func assertTaskRunAndExit(t *testing.T, h *serviceIntegrationHarness, ctx context.Context, req *taskapi.CreateTaskRequest, unit string, wantExit uint32) {
+	t.Helper()
+
+	created, err := h.service.Create(ctx, req)
+	if err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if created.Pid == 0 {
+		t.Fatal("create returned a zero pid")
+	}
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("wait for task: %v", err)
+	}
+	if waited.ExitStatus != wantExit {
+		t.Fatalf("wait exit status = %d, want %d", waited.ExitStatus, wantExit)
+	}
+
+	exited := waitForProcessExit(t, h.service.events, req.ID, req.ID)
+	if exited.ExitStatus != wantExit {
+		t.Fatalf("event exit status = %d, want %d", exited.ExitStatus, wantExit)
+	}
+
+	deleted, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+	if deleted.ExitStatus != wantExit {
+		t.Fatalf("delete exit status = %d, want %d", deleted.ExitStatus, wantExit)
+	}
+	if _, err := os.Stat(filepath.Join(h.unitDir, unit)); !os.IsNotExist(err) {
+		t.Fatalf("unit file still exists after delete: %v", err)
+	}
+	assertNoProcessExit(t, h.service.events, req.ID, req.ID, 300*time.Millisecond)
+}
+
+func assertExecRunAndExit(t *testing.T, h *serviceIntegrationHarness, ctx context.Context, req *taskapi.CreateTaskRequest, execID, execUnit string, wantExit uint32) {
+	t.Helper()
+
+	started, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID, ExecID: execID})
+	if err != nil {
+		t.Fatalf("start exec: %v", err)
+	}
+	if started.Pid == 0 {
+		t.Fatal("start exec returned a zero pid")
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID, ExecID: execID})
+	if err != nil {
+		t.Fatalf("wait for exec: %v", err)
+	}
+	if waited.ExitStatus != wantExit {
+		t.Fatalf("wait exit status = %d, want %d", waited.ExitStatus, wantExit)
+	}
+
+	startedEvent, exited := waitForExecStartedThenExit(t, h.service.events, req.ID, execID)
+	if startedEvent.Pid != started.Pid {
+		t.Fatalf("started event pid = %d, want %d", startedEvent.Pid, started.Pid)
+	}
+	if exited.ExitStatus != wantExit {
+		t.Fatalf("event exit status = %d, want %d", exited.ExitStatus, wantExit)
+	}
+
+	deleted, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID, ExecID: execID})
+	if err != nil {
+		t.Fatalf("delete exec: %v", err)
+	}
+	if deleted.ExitStatus != wantExit {
+		t.Fatalf("delete exit status = %d, want %d", deleted.ExitStatus, wantExit)
+	}
+	if _, err := os.Stat(filepath.Join(h.unitDir, execUnit)); !os.IsNotExist(err) {
+		t.Fatalf("exec unit file still exists after delete: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(req.Bundle, "execs", execID)); !os.IsNotExist(err) {
+		t.Fatalf("exec state directory still exists after delete: %v", err)
+	}
+	assertNoProcessExit(t, h.service.events, req.ID, execID, 300*time.Millisecond)
 }

--- a/service_integration_test.go
+++ b/service_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -555,6 +556,75 @@ func TestServiceTaskRootfsMountAgainstSystemd(t *testing.T) {
 	}
 }
 
+// TestServiceTaskMissedExitSignalAgainstSystemd asserts a task whose exit signal
+// the shim never observed still reports its real exit status through delete.
+// This is the case the unit reference exists for: with the exited unit kept
+// loaded, delete recovers the terminal state from systemd instead of blocking on
+// an in-memory state that never saw the exit.
+func TestServiceTaskMissedExitSignalAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	ctx, req, unit := h.task(t, "missed-exit", runcStubConfig{ExitCode: 7, ExitDelay: 300 * time.Millisecond})
+
+	if _, err := h.service.Create(ctx, req); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+
+	// Drop the event stream before the workload exits, so nothing reconciles the
+	// exit into process state.
+	h.stopReactor()
+
+	if !eventually(15*time.Second, 20*time.Millisecond, func() bool {
+		st, err := loadExitFromUnit(ctx, h.conn, unit)
+		return err == nil && st.Exited()
+	}) {
+		t.Fatal("unit never exited in systemd")
+	}
+	state, err := h.service.State(ctx, &taskapi.StateRequest{ID: req.ID})
+	if err != nil {
+		t.Fatalf("state: %v", err)
+	}
+	if state.Status == tasktypes.Status_STOPPED {
+		t.Skip("shim recorded the exit without the event stream; cannot exercise the missed-signal path")
+	}
+
+	// Delete must not be left waiting on an exit that already happened. Bound it
+	// here rather than relying on the request context: waitForExit parks in
+	// sync.Cond.Wait, which no context can interrupt, so a regression hangs
+	// forever instead of returning a deadline error.
+	delCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	type deleteResult struct {
+		resp *taskapi.DeleteResponse
+		err  error
+	}
+	done := make(chan deleteResult, 1)
+	go func() {
+		resp, err := h.service.Delete(delCtx, &taskapi.DeleteRequest{ID: req.ID})
+		done <- deleteResult{resp, err}
+	}()
+
+	var deleted *taskapi.DeleteResponse
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("delete task: %v", res.err)
+		}
+		deleted = res.resp
+	case <-time.After(30 * time.Second):
+		t.Fatal("delete blocked: the exit recorded on the still-loaded unit was never applied to the task")
+	}
+
+	if deleted.ExitStatus != 7 {
+		t.Errorf("delete reported exit status %d, want 7 recovered from the still-loaded unit", deleted.ExitStatus)
+	}
+	if !deleted.ExitedAt.AsTime().After(timeZero) {
+		t.Errorf("delete reported exit time %s, want the recovered exit stamped", deleted.ExitedAt.AsTime())
+	}
+}
+
 // requireBindMount skips the test when this environment cannot bind mount, e.g.
 // a user systemd manager whose units run without CAP_SYS_ADMIN. The shim's
 // rootfs mount runs in a systemd unit with the same privileges as this process,
@@ -575,6 +645,10 @@ type serviceIntegrationHarness struct {
 	conn      *systemd.Conn
 	unitDir   string
 	namespace string
+	// stopReactor drops the D-Bus event stream, so unit state changes stop being
+	// reconciled into process state. Tests use it to simulate a missed exit
+	// signal. It is idempotent and also runs at cleanup.
+	stopReactor func()
 }
 
 func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
@@ -582,6 +656,11 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 	busPath, unitDir := integrationSystemdManager(t)
 	ctx := context.Background()
 	conn := dialPrivate(t, ctx, busPath)
+	pinConn, pinRef, err := newPinConnection(ctx)
+	if err != nil {
+		t.Logf("no D-Bus message bus for unit references; pinning disabled: %v", err)
+		pinConn, pinRef = nil, nil
+	}
 
 	helperDir := t.TempDir()
 	testBinary, err := os.Executable()
@@ -600,11 +679,16 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 			LogMode: options.LogMode_NULL,
 		},
 		conn:    conn,
+		pinConn: pinConn,
+		pinRef:  pinRef,
 		runcBin: filepath.Join(helperDir, runcStubHelperName),
 		exe:     filepath.Join(helperDir, shimCreateHelperName),
 	})
 	if err != nil {
 		conn.Close()
+		if pinConn != nil {
+			pinConn.Close()
+		}
 		t.Fatalf("create service: %v", err)
 	}
 
@@ -621,22 +705,33 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 		reactor.consume(reactorCtx, unitUpdates(reactorCtx, signals))
 	}()
 
+	var stopReactorOnce sync.Once
+	stopReactor := func() {
+		stopReactorOnce.Do(func() {
+			cancelReactor()
+			select {
+			case <-reactorDone:
+			case <-time.After(5 * time.Second):
+				t.Error("event reactor did not stop")
+			}
+		})
+	}
+
 	t.Cleanup(func() {
-		cancelReactor()
+		stopReactor()
 		signalConn.Close()
-		select {
-		case <-reactorDone:
-		case <-time.After(5 * time.Second):
-			t.Error("event reactor did not stop")
-		}
 		conn.Close()
+		if pinConn != nil {
+			pinConn.Close()
+		}
 	})
 
 	return &serviceIntegrationHarness{
-		service:   service,
-		conn:      conn,
-		unitDir:   unitDir,
-		namespace: fmt.Sprintf("itest-%d-%d", os.Getpid(), time.Now().UnixNano()),
+		service:     service,
+		conn:        conn,
+		unitDir:     unitDir,
+		namespace:   fmt.Sprintf("itest-%d-%d", os.Getpid(), time.Now().UnixNano()),
+		stopReactor: stopReactor,
 	}
 }
 

--- a/start.go
+++ b/start.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -18,7 +17,8 @@ import (
 	"github.com/containerd/errdefs"
 	"github.com/containerd/errdefs/pkg/errgrpc"
 	"github.com/containerd/log"
-	"github.com/coreos/go-systemd/v22/unit"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+	dbus "github.com/godbus/dbus/v5"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
@@ -95,54 +95,70 @@ func (p *process) runcCmd(cmd []string) ([]string, error) {
 	return append(root, cmd...), nil
 }
 
-func writeUnit(path string, opts []*unit.UnitOption) error {
-	rdr := unit.Serialize(opts)
-
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	if _, err := io.Copy(f, rdr); err != nil {
-		return err
-	}
-	return nil
+// execCommand mirrors systemd's transient exec tuple `(sasb)`: the binary path,
+// the full argv (starting with argv[0]), and whether a non-zero exit is ignored
+// (the unit-file "-" prefix). go-systemd only ships a helper for ExecStart, so
+// this covers ExecStartPre/ExecStopPost uniformly too.
+type execCommand struct {
+	Path       string
+	Args       []string
+	IgnoreFail bool
 }
 
-func (p *initProcess) startOptions(rcmd []string) ([]*unit.UnitOption, error) {
-	const svc = "Service"
+// propExecCommand builds an Exec* property (ExecStart, ExecStartPre,
+// ExecStopPost, ...) from one or more exec tuples. The value marshals to the
+// `a(sasb)` type systemd expects for transient units.
+func propExecCommand(name string, cmds ...execCommand) systemd.Property {
+	return systemd.Property{Name: name, Value: dbus.MakeVariant(cmds)}
+}
 
-	opts := []*unit.UnitOption{
-		unit.NewUnitOption(svc, "Type", p.unitType()),
-		unit.NewUnitOption(svc, "RemainAfterExit", "no"),
-		unit.NewUnitOption(svc, "WorkingDirectory", p.Bundle),
-		unit.NewUnitOption(svc, "PIDFile", p.pidFile()),
-		unit.NewUnitOption(svc, "Environment", "PIDFILE="+p.pidFile()),
-		unit.NewUnitOption(svc, "Delegate", "yes"),
-		// Set this as env vars here because we only want these fifos to be used for the container stdio, not the other commands we run.
-		// Otherwise we can run into interesting cases like the client has closeed the fifo and our Pre/Post commands hang
-		// We already had to open these fifos in process to prevent such hangs with `ExecStart`, now instead it'll open them just before
-		// executing runc.
-		unit.NewUnitOption(svc, "Environment", "STDIN_FIFO="+p.Stdin),
-		unit.NewUnitOption(svc, "Environment", "STDOUT_FIFO="+p.Stdout),
-		unit.NewUnitOption(svc, "Environment", "STDERR_FIFO="+p.Stderr),
-		unit.NewUnitOption(svc, "Environment", "UNIT_NAME=%n"), // %n is replaced with the unit name by systemd
-		unit.NewUnitOption(svc, "Environment", "EXIT_STATE_PATH="+p.exitStatePath()),
+// formatUnitProperties renders transient-unit properties for debug output. The
+// shim no longer writes a unit file, so this stands in for reading one back when
+// reporting a failed start.
+func formatUnitProperties(props []systemd.Property) string {
+	var b strings.Builder
+	for _, p := range props {
+		fmt.Fprintf(&b, "%s=%v\n", p.Name, p.Value.Value())
+	}
+	return b.String()
+}
+
+func (p *initProcess) startProperties(rcmd []string) ([]systemd.Property, error) {
+	env := []string{
+		"PIDFILE=" + p.pidFile(),
+		// Set the container stdio fifos as env vars so they are only used for the
+		// container stdio, not the other commands we run. Otherwise we can hit
+		// cases where the client has closed the fifo and our Pre/Post commands
+		// hang. The create re-exec opens them just before executing runc.
+		"STDIN_FIFO=" + p.Stdin,
+		"STDOUT_FIFO=" + p.Stdout,
+		"STDERR_FIFO=" + p.Stderr,
+		"UNIT_NAME=" + p.Name(),
+		"EXIT_STATE_PATH=" + p.exitStatePath(),
 	}
 	if p.shimCgroup != "" {
-		opts = append(opts, unit.NewUnitOption(svc, "Environment", "SHIM_CGROUP="+p.shimCgroup))
+		env = append(env, "SHIM_CGROUP="+p.shimCgroup)
+	}
+
+	props := []systemd.Property{
+		systemd.PropType(p.unitType()),
+		systemd.PropRemainAfterExit(false),
+		{Name: "WorkingDirectory", Value: dbus.MakeVariant(p.Bundle)},
+		{Name: "PIDFile", Value: dbus.MakeVariant(p.pidFile())},
+		{Name: "Delegate", Value: dbus.MakeVariant(true)},
 	}
 
 	prefix := []string{p.exe, "--debug=" + strconv.FormatBool(p.runc.Debug), "--bundle=" + p.Bundle, "create"}
 	if len(p.Rootfs) > 0 {
 		if p.noNewNamespace {
-			opts = append(opts, unit.NewUnitOption(svc, "ExecStartPre", p.exe+" mount "+p.mountConfigPath()))
-			opts = append(opts, unit.NewUnitOption(svc, "ExecStopPost", "-"+p.exe+" unmount "+filepath.Join(p.Bundle, "rootfs")))
+			props = append(props,
+				propExecCommand("ExecStartPre", execCommand{Path: p.exe, Args: []string{p.exe, "mount", p.mountConfigPath()}}),
+				propExecCommand("ExecStopPost", execCommand{Path: p.exe, Args: []string{p.exe, "unmount", filepath.Join(p.Bundle, "rootfs")}, IgnoreFail: true}),
+			)
 		} else {
 			// Unfortunately with PrivateMounts we can't use `ExecStartPre` to mount the rootfs b/c it does not share a mount namespace
 			// with the main process. Instead we re-exec with `create` subcommand which will mount and exec the main process.
-			opts = append(opts, unit.NewUnitOption(svc, "PrivateMounts", "yes"))
+			props = append(props, systemd.Property{Name: "PrivateMounts", Value: dbus.MakeVariant(true)})
 			prefix = append(prefix, "--mounts="+p.mountConfigPath())
 		}
 	}
@@ -155,35 +171,36 @@ func (p *initProcess) startOptions(rcmd []string) ([]*unit.UnitOption, error) {
 	if err != nil {
 		return nil, err
 	}
-	opts = append(opts, unit.NewUnitOption(svc, "ExecStart", strings.Join(append(prefix, execStart...), " ")))
+	argv := append(prefix, execStart...)
+	props = append(props,
+		propExecCommand("ExecStart", execCommand{Path: argv[0], Args: argv}),
+		systemd.Property{Name: "Environment", Value: dbus.MakeVariant(env)},
+	)
 
-	return opts, nil
+	return props, nil
 }
 
-func (p *execProcess) startOptions() ([]*unit.UnitOption, error) {
-	const svc = "Service"
-
-	opts := []*unit.UnitOption{
-		unit.NewUnitOption(svc, "Type", "notify"),
-		unit.NewUnitOption(svc, "WorkingDirectory", p.parent.Bundle),
-		unit.NewUnitOption(svc, "PIDFile", p.pidFile()),
-		unit.NewUnitOption(svc, "Environment", "PIDFILE="+p.pidFile()),
-		unit.NewUnitOption(svc, "GuessMainPID", "yes"),
-		unit.NewUnitOption(svc, "Delegate", "yes"),
-		unit.NewUnitOption(svc, "RemainAfterExit", "no"),
-
-		// Set this as env vars here because we only want these fifos to be used for the container stdio, not the other commands we run.
-		// Otherwise we can run into interesting cases like the client has closeed the fifo and our Pre/Post commands hang
-		// We already had to open these fifos in process to prevent such hangs with `ExecStart`, now instead it'll open them just before
-		// executing runc.
-		unit.NewUnitOption(svc, "Environment", "STDIN_FIFO="+p.Stdin),
-		unit.NewUnitOption(svc, "Environment", "STDOUT_FIFO="+p.Stdout),
-		unit.NewUnitOption(svc, "Environment", "STDERR_FIFO="+p.Stderr),
-		unit.NewUnitOption(svc, "Environment", "UNIT_NAME=%n"), // %n is replaced with the unit name by systemd
-		unit.NewUnitOption(svc, "Environment", "EXIT_STATE_PATH="+p.exitStatePath()),
+func (p *execProcess) startProperties() ([]systemd.Property, error) {
+	env := []string{
+		"PIDFILE=" + p.pidFile(),
+		// See the note in initProcess.startProperties on why stdio fifos are env vars.
+		"STDIN_FIFO=" + p.Stdin,
+		"STDOUT_FIFO=" + p.Stdout,
+		"STDERR_FIFO=" + p.Stderr,
+		"UNIT_NAME=" + p.Name(),
+		"EXIT_STATE_PATH=" + p.exitStatePath(),
 	}
 	if p.shimCgroup != "" {
-		opts = append(opts, unit.NewUnitOption(svc, "Environment", "SHIM_CGROUP="+p.shimCgroup))
+		env = append(env, "SHIM_CGROUP="+p.shimCgroup)
+	}
+
+	props := []systemd.Property{
+		systemd.PropType("notify"),
+		systemd.PropRemainAfterExit(false),
+		{Name: "WorkingDirectory", Value: dbus.MakeVariant(p.parent.Bundle)},
+		{Name: "PIDFile", Value: dbus.MakeVariant(p.pidFile())},
+		{Name: "GuessMainPID", Value: dbus.MakeVariant(true)},
+		{Name: "Delegate", Value: dbus.MakeVariant(true)},
 	}
 
 	prefix := []string{p.exe, "--debug=" + strconv.FormatBool(p.runc.Debug), "--bundle=" + p.parent.Bundle, "create"}
@@ -195,8 +212,7 @@ func (p *execProcess) startOptions() ([]*unit.UnitOption, error) {
 			return nil, err
 		}
 
-		cmd = append(cmd, "-t")
-		cmd = append(cmd, "--console-socket="+s)
+		cmd = append(cmd, "-t", "--console-socket="+s)
 		prefix = append(prefix, "--tty")
 	}
 
@@ -204,10 +220,13 @@ func (p *execProcess) startOptions() ([]*unit.UnitOption, error) {
 	if err != nil {
 		return nil, err
 	}
-	execStart = append(prefix, execStart...)
-	opts = append(opts, unit.NewUnitOption(svc, "ExecStart", strings.Join(execStart, " ")))
+	argv := append(prefix, execStart...)
+	props = append(props,
+		propExecCommand("ExecStart", execCommand{Path: argv[0], Args: argv}),
+		systemd.Property{Name: "Environment", Value: dbus.MakeVariant(env)},
+	)
 
-	return opts, nil
+	return props, nil
 }
 
 func (p *process) unitType() string {
@@ -261,10 +280,7 @@ func (p *initProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 		p.cond.Broadcast()
 
 		if p.runc.Debug {
-			unitData, err := os.ReadFile(p.unitPath())
-			if err == nil {
-				ret = fmt.Errorf("%w:\n%s\n%s", ret, p.Name(), unitData)
-			}
+			ret = fmt.Errorf("%w:\n%s\n%s", ret, p.Name(), formatUnitProperties(p.unitProps))
 
 			processData, err := os.ReadFile(filepath.Join(p.Bundle, "config.json"))
 			if err == nil {
@@ -340,10 +356,25 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 		}()
 	}
 
+	props, err := p.startProperties()
+	if err != nil {
+		return 0, err
+	}
+
 	p.clearRecordedSystemdExitState()
 	ch := make(chan string, 1)
-	if _, err := p.systemd.StartUnitContext(ctx, p.Name(), "replace", ch); err != nil {
-		return 0, err
+	if _, err := p.systemd.StartTransientUnitContext(ctx, p.Name(), "replace", props, ch); err != nil {
+		// A prior attempt may have left a failed transient unit of the same
+		// name that systemd has not yet garbage-collected; reset it and retry.
+		if e := p.systemd.ResetFailedUnitContext(ctx, p.Name()); e != nil {
+			log.G(ctx).WithField("unit", p.Name()).WithError(e).Warn("Error resetting failed unit")
+		} else {
+			ch = make(chan string, 1)
+			_, err = p.systemd.StartTransientUnitContext(ctx, p.Name(), "replace", props, ch)
+		}
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	select {
@@ -367,11 +398,7 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 
 			ret := fmt.Errorf("error starting exec process")
 			if p.runc.Debug {
-				ret = fmt.Errorf("%w:\n%s", ret, p.Name())
-				unitData, err := os.ReadFile(p.unitPath())
-				if err == nil {
-					ret = fmt.Errorf("%w:\n%s\n%s", ret, p.Name(), unitData)
-				}
+				ret = fmt.Errorf("%w:\n%s\n%s", ret, p.Name(), formatUnitProperties(props))
 
 				processData, err := os.ReadFile(p.processFilePath())
 				if err == nil {

--- a/start.go
+++ b/start.go
@@ -236,6 +236,38 @@ func (p *process) unitType() string {
 	return "forking"
 }
 
+// abandonStartedUnit tears down a unit whose process was deleted while it was
+// starting. The delete already ran its teardown against a unit that did not
+// exist yet, so it is this caller's job to stop the unit and release the
+// reference it just took, or both would outlive the process untracked.
+func (p *process) abandonStartedUnit(ctx context.Context, name string) {
+	// Stopping gets its own budget. Releasing the reference is the part that must
+	// not be skipped, so a unit that refuses to stop must not be able to spend the
+	// time the release needs.
+	stopCtx, cancelStop := cleanupContext(ctx)
+	ch := make(chan string, 1)
+	if _, err := p.systemd.StopUnitContext(stopCtx, name, "replace", ch); err != nil {
+		log.G(ctx).WithField("unit", name).WithError(err).Info("Failed to stop unit for a deleted process")
+	} else {
+		select {
+		case <-stopCtx.Done():
+		case <-ch:
+		}
+	}
+	cancelStop()
+
+	killCtx, cancelKill := cleanupContext(ctx)
+	p.systemd.KillUnitContext(killCtx, name, int32(syscall.SIGKILL))
+	cancelKill()
+
+	// The release gets the last, unshared budget: it is the one step whose
+	// failure is unrecoverable, so no earlier call may spend its time.
+	relCtx, cancel := cleanupContext(ctx)
+	defer cancel()
+	p.releaseUnit(relCtx, name)
+	p.systemd.ResetFailedUnitContext(relCtx, name)
+}
+
 func (p *initProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 	ctx, span := StartSpan(ctx, "InitProcess.Start")
 	defer func() {
@@ -324,14 +356,34 @@ func (p *initProcess) restore(ctx context.Context) (pid uint32, retErr error) {
 		}
 		defer func() {
 			if retErr != nil {
-				p.systemd.KillUnitContext(ctx, u, int32(syscall.SIGKILL))
+				cleanupCtx, cancel := cleanupContext(ctx)
+				defer cancel()
+				p.systemd.KillUnitContext(cleanupCtx, u, int32(syscall.SIGKILL))
 			}
 		}()
 	}
-	return p.startUnit(ctx)
+	// startUnit can leave a unit behind even when it ultimately fails, so check on
+	// every return rather than only on success: a delete racing this start is
+	// already untracked and would never release it.
+	defer func() {
+		if !p.isDeleting() {
+			return
+		}
+		p.abandonStartedUnit(ctx, p.Name())
+		pid = 0
+		if retErr == nil {
+			retErr = fmt.Errorf("task %s was deleted while starting: %w", p.id, errdefs.ErrFailedPrecondition)
+		}
+	}()
+
+	pid, err := p.startUnit(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return pid, nil
 }
 
-func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
+func (p *execProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 	if !p.parent.ProcessState().Started() {
 		p.parent.LoadState(ctx)
 		if !p.parent.ProcessState().Started() {
@@ -351,7 +403,9 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 
 		defer func() {
 			if retErr != nil {
-				p.systemd.KillUnitContext(ctx, u, int32(syscall.SIGKILL))
+				cleanupCtx, cancel := cleanupContext(ctx)
+				defer cancel()
+				p.systemd.KillUnitContext(cleanupCtx, u, int32(syscall.SIGKILL))
 			}
 		}()
 	}
@@ -362,15 +416,33 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 	}
 
 	p.clearRecordedSystemdExitState()
+
+	// Installed before the unit is created, not after: StartTransientUnit can
+	// fail ambiguously (a lost or cancelled reply) with systemd having already
+	// created the unit and applied AddRef, so even its error paths have to hand
+	// the reference back if a delete raced us here. The delete ran its teardown
+	// against a unit that did not exist yet, and the exec is untracked by now, so
+	// nothing else would ever release it.
+	defer func() {
+		if !p.isDeleting() {
+			return
+		}
+		p.abandonStartedUnit(ctx, p.Name())
+		pid = 0
+		if retErr == nil {
+			retErr = fmt.Errorf("exec %s was deleted while starting: %w", p.execID, errdefs.ErrFailedPrecondition)
+		}
+	}()
+
 	ch := make(chan string, 1)
-	if _, err := p.systemd.StartTransientUnitContext(ctx, p.Name(), "replace", props, ch); err != nil {
+	if err := p.startTransientUnit(ctx, p.Name(), "replace", props, ch); err != nil {
 		// A prior attempt may have left a failed transient unit of the same
 		// name that systemd has not yet garbage-collected; reset it and retry.
 		if e := p.systemd.ResetFailedUnitContext(ctx, p.Name()); e != nil {
 			log.G(ctx).WithField("unit", p.Name()).WithError(e).Warn("Error resetting failed unit")
 		} else {
 			ch = make(chan string, 1)
-			_, err = p.systemd.StartTransientUnitContext(ctx, p.Name(), "replace", props, ch)
+			err = p.startTransientUnit(ctx, p.Name(), "replace", props, ch)
 		}
 		if err != nil {
 			return 0, err
@@ -380,7 +452,9 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 	select {
 	case <-ctx.Done():
 		log.G(ctx).WithError(ctx.Err()).Warn("start: context cancelled, killing exec unit")
-		p.systemd.KillUnitContext(context.TODO(), p.Name(), int32(syscall.SIGKILL))
+		killCtx, cancel := cleanupContext(ctx)
+		defer cancel()
+		p.systemd.KillUnitContext(killCtx, p.Name(), int32(syscall.SIGKILL))
 	case status := <-ch:
 		if status != "done" {
 			if err := p.LoadState(ctx); err != nil {
@@ -429,7 +503,7 @@ func (p *execProcess) Start(ctx context.Context) (_ uint32, retErr error) {
 		return 0, ret
 	}
 
-	pid, err := p.getPid(ctx)
+	pid, err = p.getPid(ctx)
 	if err != nil {
 		return 0, err
 	}

--- a/unitref.go
+++ b/unitref.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/containerd/log"
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+)
+
+const (
+	systemdDBusName = "org.freedesktop.systemd1"
+	systemdDBusPath = dbus.ObjectPath("/org/freedesktop/systemd1")
+)
+
+// connectSystemdMessageBus dials the D-Bus message bus systemd is registered on:
+// the system bus as root, otherwise the caller's session bus (a user manager).
+// Unlike systemd's private socket, a message-bus connection has a unique bus
+// name, which unit references are anchored to -- AddRef/UnrefUnit reject a
+// private-bus caller (it has no sender) with EINVAL.
+func connectSystemdMessageBus(ctx context.Context) (*dbus.Conn, error) {
+	if os.Geteuid() == 0 {
+		return dbus.ConnectSystemBus(dbus.WithContext(ctx))
+	}
+	return dbus.ConnectSessionBus(dbus.WithContext(ctx))
+}
+
+// newPinConnection opens a single message-bus connection for pinning transient
+// units. It returns a go-systemd Conn used to StartTransientUnit with AddRef
+// (which also gives StartTransientUnit its job-completion channel) and the raw
+// method connection the reference is anchored to, used for UnrefUnit (which
+// go-systemd does not expose). Both wrap the same underlying connection, so one
+// bus name owns every reference and UnrefUnit releases what AddRef took;
+// closing the Conn closes both.
+func newPinConnection(ctx context.Context) (*systemd.Conn, *dbus.Conn, error) {
+	var method *dbus.Conn
+	dialed := 0
+	conn, err := systemd.NewConnection(func() (*dbus.Conn, error) {
+		c, err := connectSystemdMessageBus(ctx)
+		if err != nil {
+			return nil, err
+		}
+		// NewConnection dials twice; the first connection is the one method
+		// calls (StartTransientUnit, UnrefUnit) go out on and that references are
+		// anchored to.
+		if dialed == 0 {
+			method = c
+		}
+		dialed++
+		return c, nil
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, method, nil
+}
+
+// unrefUnit releases the reference AddRef installed on a transient unit, letting
+// systemd collect it once inactive. refConn must be the method connection the
+// reference was taken on.
+func unrefUnit(ctx context.Context, refConn *dbus.Conn, name string) error {
+	return refConn.Object(systemdDBusName, systemdDBusPath).
+		CallWithContext(ctx, systemdDBusName+".Manager.UnrefUnit", 0, name).Err
+}
+
+// startTransientUnit starts the process's transient unit. When a pin connection
+// is configured it starts on that message-bus connection with AddRef=true, so
+// systemd takes a reference atomically with unit creation: the unit then stays
+// queryable over D-Bus after a clean exit -- the shim's source of truth for
+// terminal state -- even if the exit signal is missed and would otherwise let
+// systemd collect it. Without a pin connection it falls back to the private
+// method connection and takes no reference.
+//
+// It does not release any existing reference: the start-retry paths that
+// re-create a unit they already started release the prior reference explicitly
+// (a referenced unit lingers and StartTransientUnit would fail "already
+// exists"), so that a *duplicate* start of a still-live unit does not strip its
+// reference.
+func (p *process) startTransientUnit(ctx context.Context, name, mode string, props []systemd.Property, ch chan string) error {
+	if p.pinConn == nil {
+		_, err := p.systemd.StartTransientUnitContext(ctx, name, mode, props, ch)
+		return err
+	}
+	pinned := make([]systemd.Property, len(props), len(props)+1)
+	copy(pinned, props)
+	pinned = append(pinned, systemd.Property{Name: "AddRef", Value: dbus.MakeVariant(true)})
+	_, err := p.pinConn.StartTransientUnitContext(ctx, name, mode, pinned, ch)
+	return err
+}
+
+// releaseUnit drops the AddRef reference taken by startTransientUnit so systemd
+// can collect the inactive transient unit at Delete. It is a no-op without a pin
+// connection. Callers tearing down after a failure must pass a context that is
+// not already canceled (see cleanupContext), since a reference that is never
+// released keeps the unit loaded.
+func (p *process) releaseUnit(ctx context.Context, name string) {
+	if p.pinConn == nil {
+		return
+	}
+	if err := unrefUnit(ctx, p.pinRef, name); err != nil {
+		log.G(ctx).WithField("unit", name).WithError(err).Debug("Failed to release transient unit reference")
+	}
+}

--- a/unitref_test.go
+++ b/unitref_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	systemd "github.com/coreos/go-systemd/v22/dbus"
+	"github.com/godbus/dbus/v5"
+)
+
+// TestStartTransientUnitAddRefSurvivesGC proves the fix for the missed-signal
+// race: a transient unit started with AddRef=true stays loaded after a clean
+// exit -- so its terminal state can still be recovered over D-Bus -- while an
+// otherwise-identical unreferenced unit is garbage-collected. The unreferenced
+// unit is the control: it proves the reference, not systemd merely keeping the
+// unit around, is what survives collection.
+func TestStartTransientUnitAddRefSurvivesGC(t *testing.T) {
+	ctx := context.Background()
+	path := privateBusPath(t)
+	reg := newUnitRegistry(t, path)
+	conn := dialPrivate(t, ctx, path)
+	defer conn.Close()
+
+	pinConn, pinRef, err := newPinConnection(ctx)
+	if err != nil {
+		t.Skipf("no D-Bus message bus for unit references: %v", err)
+	}
+	defer pinConn.Close()
+
+	// unitLoaded reports whether systemd still holds the unit. It uses
+	// Manager.GetUnit, which does NOT load the unit -- unlike a property read on
+	// the unit's object path, which re-materializes a collected transient unit as
+	// an empty one -- so it distinguishes a still-present unit from a collected
+	// one. pinRef is the raw message-bus (godbus) connection; unit load state is
+	// global, so it observes the same units the private connection created.
+	unitLoaded := func(name string) bool {
+		var p dbus.ObjectPath
+		err := pinRef.Object(systemdDBusName, systemdDBusPath).
+			CallWithContext(ctx, systemdDBusName+".Manager.GetUnit", 0, name).Store(&p)
+		return err == nil
+	}
+
+	// Both units exit cleanly (code 0), leaving them inactive-dead -- the state
+	// systemd garbage-collects once unreferenced. ("exit 0" is a shell builtin, so
+	// it does not depend on the unit's PATH.) AddRef takes the reference
+	// atomically with unit creation, the way startTransientUnit does.
+	pinned := reg.unit("addref-pinned")
+	control := reg.unit("addref-control")
+
+	startClean := func(name string, addRef bool) {
+		t.Helper()
+		props := []systemd.Property{
+			systemd.PropExecStart([]string{"/bin/sh", "-c", "exit 0"}, false),
+			{Name: "Type", Value: dbus.MakeVariant("exec")},
+		}
+		if addRef {
+			props = append(props, systemd.Property{Name: "AddRef", Value: dbus.MakeVariant(true)})
+		}
+		ch := make(chan string, 1)
+		if _, err := pinConn.StartTransientUnitContext(ctx, name, "replace", props, ch); err != nil {
+			t.Fatalf("start %s: %v", name, err)
+		}
+		select {
+		case status := <-ch:
+			if status != "done" {
+				t.Fatalf("start %s: status %s", name, status)
+			}
+		case <-time.After(10 * time.Second):
+			t.Fatalf("timed out starting %s", name)
+		}
+	}
+
+	startClean(pinned, true)
+	startClean(control, false)
+
+	// Confirm both exited cleanly, reading their exit while still loaded.
+	for _, name := range []string{pinned, control} {
+		var st pState
+		if !eventually(10*time.Second, 20*time.Millisecond, func() bool {
+			s, err := loadExitFromUnit(ctx, conn, name)
+			if err == nil && s.Exited() {
+				st = s
+				return true
+			}
+			return false
+		}) {
+			t.Fatalf("%s never reported an exit via systemd", name)
+		}
+		if st.ExitCode != 0 {
+			t.Fatalf("%s did not exit cleanly (code %d); a failed unit lingers regardless of the reference", name, st.ExitCode)
+		}
+	}
+
+	// The unreferenced control is collected once systemd's GC queue runs (churn
+	// via ListUnits drives it). Probe collection with GetUnit, not a property
+	// read, so the probe itself does not reload it.
+	if !eventually(10*time.Second, 50*time.Millisecond, func() bool {
+		for i := 0; i < 20; i++ {
+			conn.ListUnitsContext(ctx)
+		}
+		return !unitLoaded(control)
+	}) {
+		t.Fatal("unreferenced control unit was not collected after a clean exit")
+	}
+	// Under the very same churn the AddRef'd unit stays loaded and its exit stays
+	// recoverable.
+	if !unitLoaded(pinned) {
+		t.Fatal("AddRef'd unit was collected after a clean exit")
+	}
+	if st, err := loadExitFromUnit(ctx, conn, pinned); err != nil || !st.Exited() {
+		t.Fatalf("AddRef'd unit's exit was not recoverable after a clean exit: err=%v state=%+v", err, st)
+	}
+
+	// The reference releases cleanly on the same connection, letting systemd
+	// finally collect the unit.
+	if err := unrefUnit(ctx, pinRef, pinned); err != nil {
+		t.Fatalf("UnrefUnit: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Container init, exec, and checkpoint-restore units are now created and started as systemd **transient units** (`StartTransientUnitContext`) instead of writing a unit file to `/run/systemd/system` and issuing a global `daemon-reload` on every create/delete.

## Why

`daemon-reload` re-parses every unit on the host, so its cost grows with the number of resident units. The benchmark harness showed it dominated systemd-shim task latency — hundreds of ms per reload, seconds per scenario.

## Effect

Head-to-head in the benchmark VM (same environment; `container`/`exec`/`scale`):

- daemon reloads: **76 → 0**; time spent in reload: **~207 s → 0**
- container lifecycle: **~5–10× faster**; exec: **~12× faster**
- create p50 ~5×, delete p50 ~8× faster; `start` latency unchanged (it never reloaded)

## Notes

- Delete no longer removes a unit file or reloads; the transient unit is released via `ResetFailedUnit` so a task/exec id can be reused. New `TestServiceTaskIDReuseAgainstSystemd` / `TestServiceExecIDReuseAgainstSystemd` cover reuse after normal, non-zero, and immediate exits.
- `assertUnitWorkingDirectory` now checks the `WorkingDirectory` service property over D-Bus rather than reading the on-disk unit file, which transient units no longer write.
- The runc test stub now removes container state on delete, matching real runc (required by the id-reuse tests).
- All systemd integration tests pass against a real bus in the VM.
