### PR TITLE
Represent process state as a state machine

### DIFF
--- a/create.go
+++ b/create.go
@@ -148,6 +148,7 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 			ns:       ns,
 			id:       r.ID,
 			opts:     opts,
+			events:   newEventOutbox(ns, s.send),
 			Stdin:    r.Stdin,
 			Stdout:   r.Stdout,
 			Stderr:   r.Stderr,
@@ -174,7 +175,6 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 		killAllOnExit:    shouldKillAllOnExit(&spec),
 		checkpoint:       r.Checkpoint,
 		parentCheckpoint: r.ParentCheckpoint,
-		sendEvent:        s.send,
 		execs: &processManager{
 			ls: make(map[string]Process),
 		},
@@ -209,7 +209,7 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 	}
 	p.SetState(ctx, pState{Pid: pid, Status: "created"})
 
-	s.send(ctx, ns, &eventsapi.TaskCreate{
+	p.events.Send(ctx, &eventsapi.TaskCreate{
 		ContainerID: r.ID,
 		Bundle:      r.Bundle,
 		Rootfs:      r.Rootfs,
@@ -262,6 +262,7 @@ func (s *Service) Exec(ctx context.Context, r *taskapi.ExecProcessRequest) (_ *e
 			ns:       ns,
 			root:     pInit.root,
 			id:       r.ExecID,
+			events:   newEventOutbox(ns, s.send),
 			Stdin:    r.Stdin,
 			Stdout:   r.Stdout,
 			Stderr:   r.Stderr,
@@ -308,7 +309,7 @@ func (s *Service) Exec(ctx context.Context, r *taskapi.ExecProcessRequest) (_ *e
 		return nil, err
 	}
 
-	s.send(ctx, ns, &eventsapi.TaskExecAdded{
+	ep.events.Send(ctx, &eventsapi.TaskExecAdded{
 		ContainerID: pInit.id,
 		ExecID:      r.ExecID,
 	})
@@ -429,10 +430,12 @@ func (p *initProcess) Create(ctx context.Context) (_ uint32, retErr error) {
 			cleanupCtx, cancel := cleanupContext(ctx)
 			defer cancel()
 			p.runc.Delete(cleanupCtx, p.id, &runc.DeleteOpts{Force: true})
-			p.mu.Lock()
-			p.deleted = true
-			p.cond.Broadcast()
-			p.mu.Unlock()
+			// Creation failed, so nothing will ever run under this process.
+			// Record that as its exit: it wakes anyone waiting on a process that
+			// can no longer start, and it leaves the caller's cleanup (which
+			// refines the exit and then tears the unit down) working against a
+			// process that has exited rather than one already marked deleted.
+			p.SetState(cleanupCtx, pState{ExitCode: 255, ExitedAt: time.Now(), Status: "failed"})
 		}
 		span.End()
 	}()

--- a/delete.go
+++ b/delete.go
@@ -188,10 +188,7 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 		// Just a debug message since this is just precautionary and the unit may not even be failed.
 		log.G(ctx).WithError(err).Debug("Failed to reset systemd unit")
 	}
-	p.mu.Lock()
-	p.deleted = true
-	p.cond.Broadcast()
-	p.mu.Unlock()
+	p.finishDelete(ctx)
 
 	p.closeTTYControl()
 
@@ -259,10 +256,7 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 			return pState{}, err
 		}
 	}
-	p.mu.Lock()
-	p.deleted = true
-	p.cond.Broadcast()
-	p.mu.Unlock()
+	p.finishDelete(ctx)
 
 	p.closeTTYControl()
 

--- a/events.go
+++ b/events.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"io"
+	"sync"
+	"time"
 
 	eventsapi "github.com/containerd/containerd/api/events"
 	"github.com/containerd/containerd/v2/core/events"
 	"github.com/containerd/containerd/v2/core/runtime"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
+	"github.com/containerd/log"
 	"github.com/sirupsen/logrus"
 )
 
@@ -30,10 +33,149 @@ type eventEnvelope struct {
 	e  interface{}
 }
 
-func (s *Service) send(ctx context.Context, ns string, e interface{}) {
+// eventPublishTimeout bounds how long a task event waits for room in the publish
+// queue. It exists so a wedged publisher cannot pin a reactor worker or an RPC
+// handler forever; it is not a cancellation path, and is deliberately generous,
+// because giving up means containerd never hears about something that happened.
+// It is a var so tests can shrink it.
+var eventPublishTimeout = 30 * time.Second
+
+// send hands an event to Forward. Its two contexts have distinct jobs. The
+// caller's supplies values only -- the unit logger and trace span -- because an
+// event records something that already happened, so whether the RPC client that
+// happened to be on the stack gave up has no bearing on whether containerd hears
+// about it, and the reactor paths have no client at all. The wait is bounded by
+// the shim's own lifetime instead, so anything the shim later wants to cancel a
+// publish for -- shutdown, a bound on queue processing -- can reach it, which
+// severing the tree with WithoutCancel would have made impossible.
+func (s *Service) send(ctx context.Context, ns string, e interface{}) bool {
+	wait, cancel := context.WithTimeout(s.publishCtx, eventPublishTimeout)
+	defer cancel()
+
 	select {
-	case <-ctx.Done():
 	case s.events <- eventEnvelope{ns, e}:
+		return true
+	case <-wait.Done():
+		log.G(ctx).WithError(wait.Err()).Errorf("Did not publish %T; containerd will not see it", e)
+		return false
+	}
+}
+
+// eventOutbox publishes one process's task events in the order containerd can
+// make sense of them.
+//
+// Each event has a precondition: containerd must have been told the process
+// exists before it is told the process is gone, must have been told a task
+// started before it is told it exited, and must be told nothing at all once it
+// has been told the process is deleted. The shim does not learn these things in
+// that order -- the reactor sees a workload die while Start is still running,
+// and a Delete can finish while that same Start is still on its way to
+// publishing -- so an event whose precondition is not met yet is held, and every
+// send re-checks the held ones to publish whatever has since become publishable.
+// An event whose precondition is never met is never published: a task deleted
+// before it ever ran, or one whose Create failed and tore itself down through
+// the ordinary teardown path, is discarded along with whatever it was still
+// holding.
+//
+// Callers hand it every event and let it decide; there is no separate "queue"
+// and "publish" entry point to pick between.
+//
+// It is held by value: every process owns exactly one and never shares it, so
+// there is nothing to point at. Copying one after use would copy its mutex,
+// which go vet's copylocks check catches.
+type eventOutbox struct {
+	ns   string
+	send func(ctx context.Context, ns string, evt interface{}) bool
+
+	// mu is held across publishing so a flush cannot be overtaken by an event
+	// racing it. send is bounded by eventPublishTimeout, so the wait is bounded
+	// backpressure on this process alone.
+	mu      sync.Mutex
+	known   bool // containerd has been told the process exists
+	started bool // containerd has been told the task started
+	deleted bool // containerd has been told the process is gone
+	held    []interface{}
+}
+
+func newEventOutbox(ns string, send func(ctx context.Context, ns string, evt interface{}) bool) eventOutbox {
+	return eventOutbox{ns: ns, send: send}
+}
+
+// Send publishes evt if containerd can make sense of it yet, and holds it until
+// it can otherwise.
+func (o *eventOutbox) Send(ctx context.Context, evt interface{}) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	o.held = append(o.held, evt)
+	o.flush(ctx)
+}
+
+// publishable reports whether evt's precondition is met. o.mu must be held.
+func (o *eventOutbox) publishable(evt interface{}) bool {
+	if o.deleted {
+		// Nothing follows a delete. A Start still on its way to publishing when
+		// a Delete completed would otherwise resurrect an untracked task in the
+		// event stream, and drag the exit held behind it along too.
+		return false
+	}
+	switch evt.(type) {
+	case *eventsapi.TaskExit:
+		return o.started
+	case *eventsapi.TaskDelete:
+		return o.known
+	}
+	return true
+}
+
+// flush publishes every held event whose precondition is now met, oldest first,
+// and leaves the rest held. It passes over the queue again for as long as a pass
+// publishes something, because publishing one event can be what meets the
+// precondition of another queued ahead of it -- which is exactly the
+// exit-observed-before-its-start case. It stops when a pass publishes nothing,
+// or early when a send fails. o.mu must be held.
+func (o *eventOutbox) flush(ctx context.Context) {
+	for {
+		var (
+			held    []interface{}
+			sent    bool
+			stalled bool
+		)
+		for i, evt := range o.held {
+			if !o.publishable(evt) {
+				held = append(held, evt)
+				continue
+			}
+			// An event is recorded only once it has actually been handed over.
+			// A create or start that never reached Forward but still counted as
+			// published would let a later delete or exit out without the
+			// prerequisite containerd never saw.
+			if !o.send(ctx, o.ns, evt) {
+				held = append(held, o.held[i:]...)
+				stalled = true
+				break
+			}
+			o.record(evt)
+			sent = true
+		}
+		o.held = held
+
+		if !sent || stalled {
+			return
+		}
+	}
+}
+
+// record notes what publishing evt has told containerd, which is what meets the
+// preconditions of later events. o.mu must be held.
+func (o *eventOutbox) record(evt interface{}) {
+	switch evt.(type) {
+	case *eventsapi.TaskCreate, *eventsapi.TaskExecAdded:
+		o.known = true
+	case *eventsapi.TaskStart, *eventsapi.TaskExecStarted:
+		o.started = true
+	case *eventsapi.TaskDelete:
+		o.deleted = true
 	}
 }
 

--- a/events_test.go
+++ b/events_test.go
@@ -1,0 +1,437 @@
+package main
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	eventsapi "github.com/containerd/containerd/api/events"
+)
+
+func TestLifecycleEventsFollowTransitions(t *testing.T) {
+	t.Run("a start is published before an exit observed while starting", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c1")
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+
+		// The reactor sees the workload die before Start returns.
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+		if got := events(); len(got) != 0 {
+			t.Fatalf("events published while starting = %v, want none held back", got)
+		}
+
+		p.finishStart(context.Background(), 42)
+
+		assertEventTypes(t, events(), &eventsapi.TaskStart{}, &eventsapi.TaskExit{})
+	})
+
+	t.Run("an exit after the start is published immediately", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c2")
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+		p.finishStart(context.Background(), 42)
+
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		assertEventTypes(t, events(), &eventsapi.TaskStart{}, &eventsapi.TaskExit{})
+	})
+
+	t.Run("an exit held behind a start that never came is not published", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c3")
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		if got := events(); len(got) != 0 {
+			t.Fatalf("events for a task that never started = %v, want none", got)
+		}
+	})
+
+	t.Run("deleting a container publishes a task delete", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c4")
+		p.events.Send(context.Background(), &eventsapi.TaskCreate{ContainerID: "c4"})
+
+		p.finishDelete(context.Background())
+
+		assertEventTypes(t, events(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("a container containerd was never told about publishes no task delete", func(t *testing.T) {
+		// A Create that fails tears its process down through the same teardown
+		// path, having never published a task create.
+		p, events := newRecordingInitProcess(t, "c4b")
+
+		p.finishDelete(context.Background())
+
+		if got := events(); len(got) != 0 {
+			t.Fatalf("events for an unannounced container = %v, want none", got)
+		}
+	})
+
+	t.Run("a container deleted before it ever started still publishes a task delete", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c5")
+		p.events.Send(context.Background(), &eventsapi.TaskCreate{ContainerID: "c5"})
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		p.finishDelete(context.Background())
+
+		// The exit stays held -- containerd was never told it started -- but the
+		// delete is not gated on a start that will never come.
+		assertEventTypes(t, events(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("a repeated delete publishes a single task delete", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c6")
+		p.events.Send(context.Background(), &eventsapi.TaskCreate{ContainerID: "c6"})
+
+		p.finishDelete(context.Background())
+		p.finishDelete(context.Background())
+
+		assertEventTypes(t, events(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("a task delete carries the recorded exit", func(t *testing.T) {
+		p, events := newRecordingInitProcess(t, "c7")
+		p.events.Send(context.Background(), &eventsapi.TaskCreate{ContainerID: "c7"})
+		exitedAt := time.Now()
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 137, ExitedAt: exitedAt, Status: "exited"})
+
+		p.finishDelete(context.Background())
+
+		got := events()
+		if len(got) != 2 {
+			t.Fatalf("events = %v, want a task create and a task delete", eventTypes(got))
+		}
+		del, ok := got[1].(*eventsapi.TaskDelete)
+		if !ok {
+			t.Fatalf("event = %T, want *events.TaskDelete", got[1])
+		}
+		if del.ContainerID != "c7" || del.Pid != 42 || del.ExitStatus != 137 {
+			t.Fatalf("task delete = %+v, want container c7, pid 42, status 137", del)
+		}
+		if !del.ExitedAt.AsTime().Equal(exitedAt.UTC()) {
+			t.Fatalf("task delete exited at %s, want %s", del.ExitedAt.AsTime(), exitedAt.UTC())
+		}
+	})
+
+	t.Run("deleting an exec publishes no task delete", func(t *testing.T) {
+		parent, events := newRecordingInitProcess(t, "c8")
+		ep := newRecordingExecProcess(parent, "exec1")
+
+		ep.advance(phaseDeleted)
+
+		if got := events(); len(got) != 0 {
+			t.Fatalf("events for an exec delete = %v, want none", got)
+		}
+	})
+
+	t.Run("an exec start is published before an exit observed while starting", func(t *testing.T) {
+		parent, events := newRecordingInitProcess(t, "c9")
+		ep := newRecordingExecProcess(parent, "exec1")
+		if err := ep.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+
+		ep.SetState(context.Background(), pState{Pid: 99, ExitCode: 2, ExitedAt: time.Now()})
+		ep.finishStart(context.Background(), 99)
+
+		assertEventTypes(t, events(), &eventsapi.TaskExecStarted{}, &eventsapi.TaskExit{})
+	})
+}
+
+// Each event has its own precondition, so a send releases whatever has become
+// publishable rather than assuming one arrival unblocks everything held.
+func TestEventOutboxReleasesOnlyWhatIsPublishable(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("a create releases a held delete and leaves a held exit alone", func(t *testing.T) {
+		o, published := newRecordingOutbox()
+		o.Send(ctx, &eventsapi.TaskExit{})
+		o.Send(ctx, &eventsapi.TaskDelete{})
+		if got := published(); len(got) != 0 {
+			t.Fatalf("published %v before either precondition was met, want none", eventTypes(got))
+		}
+
+		o.Send(ctx, &eventsapi.TaskCreate{})
+
+		assertEventTypes(t, published(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("a start releases a held exit and leaves a held delete alone", func(t *testing.T) {
+		o, published := newRecordingOutbox()
+		o.Send(ctx, &eventsapi.TaskExit{})
+		o.Send(ctx, &eventsapi.TaskDelete{})
+
+		o.Send(ctx, &eventsapi.TaskStart{})
+
+		assertEventTypes(t, published(), &eventsapi.TaskStart{}, &eventsapi.TaskExit{})
+	})
+
+	t.Run("each precondition releases its own event as it is met", func(t *testing.T) {
+		o, published := newRecordingOutbox()
+		o.Send(ctx, &eventsapi.TaskExit{})
+		o.Send(ctx, &eventsapi.TaskDelete{})
+
+		o.Send(ctx, &eventsapi.TaskStart{})
+		o.Send(ctx, &eventsapi.TaskCreate{})
+
+		assertEventTypes(t, published(),
+			&eventsapi.TaskStart{}, &eventsapi.TaskExit{},
+			&eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("nothing is published after a delete", func(t *testing.T) {
+		o, published := newRecordingOutbox()
+		o.Send(ctx, &eventsapi.TaskCreate{})
+		o.Send(ctx, &eventsapi.TaskDelete{})
+
+		// A Start still on its way to publishing when the Delete completed.
+		o.Send(ctx, &eventsapi.TaskStart{})
+		o.Send(ctx, &eventsapi.TaskExit{})
+
+		assertEventTypes(t, published(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("a delete does not release the exit held behind a start", func(t *testing.T) {
+		o, published := newRecordingOutbox()
+		o.Send(ctx, &eventsapi.TaskCreate{})
+		o.Send(ctx, &eventsapi.TaskExit{})
+
+		o.Send(ctx, &eventsapi.TaskDelete{})
+		o.Send(ctx, &eventsapi.TaskStart{})
+
+		assertEventTypes(t, published(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+}
+
+// A send that is not delivered must not count as published: recording its
+// prerequisite would let a later event out without the one containerd never saw.
+func TestEventOutboxHoldsUndeliveredEvents(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("an undelivered create does not let a later delete out", func(t *testing.T) {
+		o, published, deliver := newBlockedOutbox()
+		deliver(false)
+		o.Send(ctx, &eventsapi.TaskCreate{})
+		if got := published(); len(got) != 0 {
+			t.Fatalf("published %v while delivery was failing, want none", eventTypes(got))
+		}
+
+		deliver(true)
+		o.Send(ctx, &eventsapi.TaskDelete{})
+
+		// The create is retried first. Had the dropped one counted as published,
+		// the delete would have gone out on its own.
+		assertEventTypes(t, published(), &eventsapi.TaskCreate{}, &eventsapi.TaskDelete{})
+	})
+
+	t.Run("an undelivered start does not let a later exit out", func(t *testing.T) {
+		o, published, deliver := newBlockedOutbox()
+		deliver(false)
+		o.Send(ctx, &eventsapi.TaskStart{})
+		if got := published(); len(got) != 0 {
+			t.Fatalf("published %v while delivery was failing, want none", eventTypes(got))
+		}
+
+		deliver(true)
+		o.Send(ctx, &eventsapi.TaskExit{})
+
+		assertEventTypes(t, published(), &eventsapi.TaskStart{}, &eventsapi.TaskExit{})
+	})
+}
+
+// An event records something that already happened, so the caller giving up must
+// not stop it reaching containerd -- but the shim's own cancellation, and the
+// publish timeout, still have to be able to end the wait.
+func TestServiceSendIsBoundToTheShimNotTheCaller(t *testing.T) {
+	t.Run("a cancelled caller still publishes", func(t *testing.T) {
+		s := &Service{events: make(chan eventEnvelope, 1), publishCtx: context.Background()}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		if !s.send(ctx, "testns", &eventsapi.TaskExit{}) {
+			t.Fatal("a cancelled caller stopped an event being published")
+		}
+
+		select {
+		case envelope := <-s.events:
+			if _, ok := envelope.e.(*eventsapi.TaskExit); !ok {
+				t.Fatalf("queued %T, want *events.TaskExit", envelope.e)
+			}
+		default:
+			t.Fatal("nothing was queued")
+		}
+	})
+
+	t.Run("a shim that is shutting down ends the wait", func(t *testing.T) {
+		// An unbuffered queue with nothing draining it stands in for a publisher
+		// that has stopped keeping up.
+		shim, shutdown := context.WithCancel(context.Background())
+		s := &Service{events: make(chan eventEnvelope), publishCtx: shim}
+
+		done := make(chan bool, 1)
+		go func() { done <- s.send(context.Background(), "testns", &eventsapi.TaskExit{}) }()
+		shutdown()
+
+		select {
+		case sent := <-done:
+			if sent {
+				t.Fatal("send reported success with nothing draining the queue")
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("send could not be cancelled by the shim shutting down")
+		}
+	})
+
+	t.Run("a publisher that stops draining times out rather than blocking", func(t *testing.T) {
+		restore := eventPublishTimeout
+		eventPublishTimeout = 10 * time.Millisecond
+		t.Cleanup(func() { eventPublishTimeout = restore })
+
+		// An unbuffered queue with nothing draining it stands in for a publisher
+		// that has stopped keeping up.
+		s := &Service{events: make(chan eventEnvelope), publishCtx: context.Background()}
+
+		done := make(chan bool, 1)
+		go func() { done <- s.send(context.Background(), "testns", &eventsapi.TaskExit{}) }()
+
+		select {
+		case sent := <-done:
+			if sent {
+				t.Fatal("send reported success with nothing draining the queue")
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("send blocked past its timeout")
+		}
+	})
+}
+
+func newRecordingOutbox() (*eventOutbox, func() []interface{}) {
+	o, published, _ := newBlockedOutbox()
+	return o, published
+}
+
+// newBlockedOutbox returns an outbox whose delivery can be turned on and off, to
+// stand in for Service.send dropping an event on a canceled request context. It
+// starts out delivering.
+func newBlockedOutbox() (*eventOutbox, func() []interface{}, func(bool)) {
+	var mu sync.Mutex
+	var published []interface{}
+	delivering := true
+
+	o := newEventOutbox("testns", func(_ context.Context, _ string, evt interface{}) bool {
+		mu.Lock()
+		defer mu.Unlock()
+		if !delivering {
+			return false
+		}
+		published = append(published, evt)
+		return true
+	})
+
+	return &o, func() []interface{} {
+			mu.Lock()
+			defer mu.Unlock()
+			return append([]interface{}(nil), published...)
+		}, func(on bool) {
+			mu.Lock()
+			delivering = on
+			mu.Unlock()
+		}
+}
+
+// discardEvents is an outbox for tests that exercise a real process but do not
+// care what it publishes.
+func discardEvents() eventOutbox {
+	return newEventOutbox("testns", func(context.Context, string, interface{}) bool { return true })
+}
+
+// newRecordingExecProcess builds an exec with its own outbox feeding the
+// parent's recorder, as Service.Exec does. Nothing has been published for it
+// yet.
+func newRecordingExecProcess(parent *initProcess, execID string) *execProcess {
+	ep := &execProcess{
+		process: &process{ns: parent.ns, id: execID, events: newEventOutbox(parent.ns, parent.events.send)},
+		parent:  parent,
+		execID:  execID,
+	}
+	ep.cond = sync.NewCond(&ep.mu)
+	return ep
+}
+
+// newRecordingInitProcess builds an initProcess whose outbox records every event
+// it publishes, in order. Nothing has been reported to containerd yet, so the
+// outbox behaves exactly as it does in production.
+func newRecordingInitProcess(t *testing.T, id string) (*initProcess, func() []interface{}) {
+	t.Helper()
+
+	var mu sync.Mutex
+	var events []interface{}
+	send := func(_ context.Context, _ string, evt interface{}) bool {
+		mu.Lock()
+		events = append(events, evt)
+		mu.Unlock()
+		return true
+	}
+
+	p := &initProcess{
+		process: &process{ns: "testns", id: id, events: newEventOutbox("testns", send)},
+		execs:   &processManager{ls: make(map[string]Process)},
+		shimLog: io.Discard,
+	}
+	p.cond = sync.NewCond(&p.mu)
+
+	return p, func() []interface{} {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]interface{}(nil), events...)
+	}
+}
+
+func assertEventTypes(t *testing.T, got []interface{}, want ...interface{}) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("published %v, want %v", eventTypes(got), eventTypes(want))
+	}
+	for i := range want {
+		if eventTypeName(got[i]) != eventTypeName(want[i]) {
+			t.Fatalf("published %v, want %v", eventTypes(got), eventTypes(want))
+		}
+	}
+}
+
+func eventTypes(evts []interface{}) []string {
+	names := make([]string, 0, len(evts))
+	for _, e := range evts {
+		names = append(names, eventTypeName(e))
+	}
+	return names
+}
+
+func eventTypeName(e interface{}) string {
+	switch e.(type) {
+	case *eventsapi.TaskCreate:
+		return "TaskCreate"
+	case *eventsapi.TaskExecAdded:
+		return "TaskExecAdded"
+	case *eventsapi.TaskStart:
+		return "TaskStart"
+	case *eventsapi.TaskExecStarted:
+		return "TaskExecStarted"
+	case *eventsapi.TaskExit:
+		return "TaskExit"
+	case *eventsapi.TaskDelete:
+		return "TaskDelete"
+	default:
+		return "unknown"
+	}
+}

--- a/integration_test.go
+++ b/integration_test.go
@@ -135,8 +135,6 @@ func awaitQuiet(timeout, step time.Duration, maxPerStep int64, total func() int6
 	return false
 }
 
-// --- integration helpers ---
-
 // TestLoadExitFromUnitReadsRealExitCode is the load-bearing check for removing
 // the ExecStopPost exit helper: with no helper writing the state file on stop,
 // the reconcile path's only source of the terminal code is systemd's

--- a/manager.go
+++ b/manager.go
@@ -129,6 +129,7 @@ func newServiceWithConfig(ctx context.Context, cfg serviceConfig) (*Service, err
 
 	debug := logrus.GetLevel() >= logrus.DebugLevel
 	return &Service{
+		publishCtx:     ctx,
 		conn:           cfg.conn,
 		pinConn:        cfg.pinConn,
 		pinRef:         cfg.pinRef,
@@ -155,8 +156,13 @@ type Service struct {
 	root           string
 	noNewNamespace bool
 	publisher      events.Publisher
-	events         chan eventEnvelope
-	waitEvents     chan struct{}
+	// publishCtx is the shim's lifetime, cancelled when the process is shutting
+	// down. Task events are published against it rather than the caller's context:
+	// a client giving up must not stop containerd hearing about something that
+	// already happened, but the shim itself still has to be able to stop the wait.
+	publishCtx context.Context
+	events     chan eventEnvelope
+	waitEvents chan struct{}
 
 	processes *processManager
 	units     *unitManager

--- a/phase.go
+++ b/phase.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/containerd/errdefs"
+)
+
+// procPhase is where a process is in its lifecycle. It is the shim's authority
+// on what may happen to a process next, and it is deliberately coarser than the
+// systemd SubState carried in pState: systemd describes a unit, while a phase
+// describes the containerd process the shim runs inside that unit.
+//
+// The two are complementary, not redundant. The phase decides created-vs-running
+// in everything the shim reports, and decides whether an operation is allowed at
+// all. The observation supplies the terminal detail the phase does not model:
+// the exit code and time, and the failed / dead / exited-init distinction
+// toStatus maps for containerd.
+//
+// The phases are ordered, so comparing against phaseRunning asks whether the
+// process has finished starting. The zero value is phaseCreated, which is where
+// every process begins.
+type procPhase uint8
+
+const (
+	// phaseCreated is a container `runc create` has set up and a unit exists
+	// for, but whose workload has not been started. systemd already reports such
+	// a unit as running, which is why the phase -- not the observation -- is what
+	// decides created-vs-running.
+	phaseCreated procPhase = iota
+	// phaseStarting is claimed by Start before it does any work, so a second
+	// start, or a start of a process that has already exited, is rejected before
+	// runc is invoked rather than after.
+	phaseStarting
+	// phaseRunning is reached once Start has returned successfully.
+	phaseRunning
+	// phaseExited is terminal for the workload: a terminal observation has been
+	// merged and nothing will run under this process again.
+	phaseExited
+	// phaseDeleted is terminal for the process: teardown finished and every
+	// further transition is rejected, so a late unit event cannot resurrect it.
+	phaseDeleted
+)
+
+func (p procPhase) String() string {
+	switch p {
+	case phaseCreated:
+		return "created"
+	case phaseStarting:
+		return "starting"
+	case phaseRunning:
+		return "running"
+	case phaseExited:
+		return "exited"
+	case phaseDeleted:
+		return "deleted"
+	default:
+		return fmt.Sprintf("procPhase(%d)", uint8(p))
+	}
+}
+
+// phaseTransitions enumerates every legal transition. Self-transitions are
+// listed where they are legal rather than allowed implicitly, so this table is
+// the whole truth about the lifecycle:
+//
+//   - created -> created, running -> running and exited -> exited absorb
+//     repeated observations; exited -> exited also lets a coarse exit be refined
+//     by a later, more precise one without counting as a second exit.
+//   - starting is a claim rather than an observation, so it is the one phase
+//     that cannot repeat: only one caller may hold a start attempt at a time,
+//     and running -> starting and exited -> starting reject starting a process
+//     that is already running or can never run again.
+//   - starting -> created hands the claim back when an attempt fails, so
+//     another can be made.
+//   - every phase may be deleted, because teardown has to work on a process that
+//     never started as well as one that did.
+var phaseTransitions = map[procPhase][]procPhase{
+	phaseCreated:  {phaseCreated, phaseStarting, phaseExited, phaseDeleted},
+	phaseStarting: {phaseCreated, phaseRunning, phaseExited, phaseDeleted},
+	phaseRunning:  {phaseRunning, phaseExited, phaseDeleted},
+	phaseExited:   {phaseExited, phaseDeleted},
+	phaseDeleted:  {phaseDeleted},
+}
+
+func (p procPhase) canBecome(next procPhase) bool {
+	return slices.Contains(phaseTransitions[p], next)
+}
+
+// invalidTransitionError reports a rejected lifecycle transition. It unwraps to
+// errdefs.ErrFailedPrecondition so a rejected API operation reaches containerd
+// with the right gRPC status without any extra mapping.
+type invalidTransitionError struct {
+	from, to procPhase
+}
+
+func (e invalidTransitionError) Error() string {
+	return fmt.Sprintf("cannot go from %s to %s", e.from, e.to)
+}
+
+func (e invalidTransitionError) Unwrap() error {
+	return errdefs.ErrFailedPrecondition
+}

--- a/phase_test.go
+++ b/phase_test.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containerd/errdefs"
+)
+
+func TestProcessPhaseTransitions(t *testing.T) {
+	t.Run("a created process can be started", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseCreated)
+
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("start a created process: %v", err)
+		}
+		if _, err := p.advance(phaseRunning); err != nil {
+			t.Fatalf("finish starting a created process: %v", err)
+		}
+		if got := p.currentPhase(); got != phaseRunning {
+			t.Fatalf("phase after a successful start = %s, want running", got)
+		}
+	})
+
+	t.Run("a start already in flight rejects a second one", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseStarting)
+
+		if err := p.beginStart(); err == nil {
+			t.Fatal("a second concurrent start was admitted")
+		}
+	})
+
+	t.Run("a start can be attempted again after the last one was abandoned", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseStarting)
+
+		p.abortStart(context.Background())
+
+		if got := p.currentPhase(); got != phaseCreated {
+			t.Fatalf("phase after an abandoned start = %s, want created", got)
+		}
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("retry a failed start: %v", err)
+		}
+	})
+
+	t.Run("abandoning a start that already exited leaves it exited", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseStarting)
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		p.abortStart(context.Background())
+
+		if got := p.currentPhase(); got != phaseExited {
+			t.Fatalf("phase after abandoning an exited start = %s, want exited", got)
+		}
+	})
+
+	t.Run("a running process cannot be started again", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseRunning)
+
+		if err := p.beginStart(); err == nil {
+			t.Fatal("starting an already running process was allowed")
+		}
+	})
+
+	t.Run("an exited process cannot be started", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseExited)
+
+		if err := p.beginStart(); err == nil {
+			t.Fatal("starting an exited process was allowed")
+		}
+	})
+
+	t.Run("a deleted process cannot be started", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseDeleted)
+
+		if err := p.beginStart(); err == nil {
+			t.Fatal("starting a deleted process was allowed")
+		}
+	})
+
+	t.Run("a process that exited while starting cannot finish its start", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseStarting)
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		if _, err := p.advance(phaseRunning); err == nil {
+			t.Fatal("a process that exited while starting finished its start")
+		}
+		if got := p.currentPhase(); got != phaseExited {
+			t.Fatalf("phase after a rejected start completion = %s, want exited", got)
+		}
+	})
+
+	t.Run("an exit from running reports that the process had been running", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseRunning)
+
+		u := p.applyState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		if !u.wasRunning() {
+			t.Fatal("an exit from running did not report the process as having been running")
+		}
+		if got := p.currentPhase(); got != phaseExited {
+			t.Fatalf("phase after an exit = %s, want exited", got)
+		}
+	})
+
+	t.Run("an exit while starting does not report the process as having been running", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseStarting)
+
+		u := p.applyState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		if u.wasRunning() {
+			t.Fatal("a process that exited mid-start was reported as having been running")
+		}
+	})
+
+	for name, phase := range map[string]procPhase{
+		"a created process can be deleted without ever running": phaseCreated,
+		"a process deleted mid-start can be deleted":            phaseStarting,
+		"a running process can be deleted":                      phaseRunning,
+		"an exited process can be deleted":                      phaseExited,
+	} {
+		t.Run(name, func(t *testing.T) {
+			p := newPhasedProcess(t, phase)
+
+			p.advance(phaseDeleted)
+
+			if got := p.currentPhase(); got != phaseDeleted {
+				t.Fatalf("phase after delete = %s, want deleted", got)
+			}
+		})
+	}
+
+	t.Run("a deleted process rejects every earlier phase", func(t *testing.T) {
+		for _, earlier := range []procPhase{phaseCreated, phaseStarting, phaseRunning, phaseExited} {
+			p := newPhasedProcess(t, phaseDeleted)
+
+			if _, err := p.advance(earlier); err == nil {
+				t.Fatalf("a deleted process was allowed to become %s", earlier)
+			}
+		}
+	})
+
+	t.Run("a rejected transition leaves the phase unchanged", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseExited)
+
+		if _, err := p.advance(phaseRunning); err == nil {
+			t.Fatal("an exited process was allowed to become running")
+		}
+		if got := p.currentPhase(); got != phaseExited {
+			t.Fatalf("phase after a rejected transition = %s, want exited", got)
+		}
+	})
+
+	t.Run("a rejected transition reports a failed precondition", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseExited)
+
+		err := p.beginStart()
+		if !errors.Is(err, errdefs.ErrFailedPrecondition) {
+			t.Fatalf("rejected start error = %v, want a failed precondition", err)
+		}
+		if want := "cannot go from exited to starting"; err.Error() != want {
+			t.Fatalf("rejected start error = %q, want %q", err, want)
+		}
+	})
+}
+
+// The exit transition is what makes an exit observable exactly once: every state
+// path funnels an exit through SetState, and only one of them can be the call
+// that moves the process into the exited phase.
+func TestProcessExitTransitionHappensOnce(t *testing.T) {
+	exited := pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()}
+
+	t.Run("repeated exit observations report a single exit transition", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseRunning)
+
+		var claimed int
+		for i := 0; i < 4; i++ {
+			if p.applyState(context.Background(), exited).justExited() {
+				claimed++
+			}
+		}
+
+		if claimed != 1 {
+			t.Fatalf("exit transitions claimed = %d, want 1", claimed)
+		}
+	})
+
+	t.Run("concurrent exit observations report a single exit transition", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseRunning)
+
+		var claimed int32
+		var wg sync.WaitGroup
+		for i := 0; i < 16; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if p.applyState(context.Background(), exited).justExited() {
+					atomic.AddInt32(&claimed, 1)
+				}
+			}()
+		}
+		wg.Wait()
+
+		if claimed != 1 {
+			t.Fatalf("exit transitions claimed under concurrency = %d, want 1", claimed)
+		}
+	})
+
+	t.Run("an exit observed after delete is not claimed", func(t *testing.T) {
+		p := newPhasedProcess(t, phaseDeleted)
+
+		if p.applyState(context.Background(), exited).justExited() {
+			t.Fatal("an exit observed after delete was claimed")
+		}
+	})
+}
+
+// These start a process with no runc configured, so a start that is not rejected
+// up front would panic rather than quietly succeed.
+func TestStartRejectsAProcessThatCannotRun(t *testing.T) {
+	t.Run("starting an exited container reports a failed precondition", func(t *testing.T) {
+		p, _ := newTestInitProcess("container")
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+
+		_, err := p.Start(context.Background())
+		if !errors.Is(err, errdefs.ErrFailedPrecondition) {
+			t.Fatalf("start of an exited container = %v, want a failed precondition", err)
+		}
+	})
+
+	t.Run("starting an exited exec reports a failed precondition", func(t *testing.T) {
+		parent, _ := newTestInitProcess("container")
+		ep := newTestExecProcess(parent, "exec1")
+		ep.SetState(context.Background(), pState{Pid: 99, ExitCode: 1, ExitedAt: time.Now()})
+
+		_, err := ep.Start(context.Background())
+		if !errors.Is(err, errdefs.ErrFailedPrecondition) {
+			t.Fatalf("start of an exited exec = %v, want a failed precondition", err)
+		}
+	})
+
+	t.Run("starting a running container reports a failed precondition", func(t *testing.T) {
+		p, _ := newTestInitProcess("container")
+		runTestProcess(t, p.process)
+
+		_, err := p.Start(context.Background())
+		if !errors.Is(err, errdefs.ErrFailedPrecondition) {
+			t.Fatalf("start of a running container = %v, want a failed precondition", err)
+		}
+	})
+}
+
+// newPhasedProcess builds a process sitting in the given phase, driving it there
+// through the same transitions the shim uses rather than assigning the field.
+func newPhasedProcess(t *testing.T, phase procPhase) *process {
+	t.Helper()
+
+	p := &process{id: "test"}
+	p.cond = sync.NewCond(&p.mu)
+
+	switch phase {
+	case phaseCreated:
+	case phaseStarting:
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("reach %s: %v", phase, err)
+		}
+	case phaseRunning:
+		runTestProcess(t, p)
+	case phaseExited:
+		runTestProcess(t, p)
+		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 1, ExitedAt: time.Now()})
+	case phaseDeleted:
+		p.advance(phaseDeleted)
+	default:
+		t.Fatalf("unknown phase %s", phase)
+	}
+
+	if got := p.currentPhase(); got != phase {
+		t.Fatalf("phase = %s, want %s", got, phase)
+	}
+	return p
+}

--- a/process.go
+++ b/process.go
@@ -219,17 +219,21 @@ type process struct {
 
 	ttyControl *ttyControlClient
 
-	mu           sync.Mutex
-	cond         *sync.Cond
-	state        pState
-	deleted      bool
-	deleting     bool
-	exitNotified bool
-	started      bool
+	mu   sync.Mutex
+	cond *sync.Cond
+	// state is the last observation merged into this process: what systemd, or
+	// the create re-exec helper, said about the unit. phase is what the shim
+	// makes of it -- see procPhase for why both exist.
+	phase    procPhase
+	state    pState
+	deleting bool
 
-	eventMu             sync.Mutex
-	startEventPublished bool
-	pendingExitEvent    func()
+	// events publishes this process's containerd task events. It decides which
+	// of them containerd may see and in what order (see eventOutbox), so callers
+	// hand it every event unconditionally. It lives here rather than on
+	// initProcess so an exec publishes its own events instead of reaching
+	// through its parent.
+	events eventOutbox
 
 	systemdExitState    pState
 	hasSystemdExitState bool
@@ -237,40 +241,65 @@ type process struct {
 	shimCgroup string
 }
 
-// claimExitNotification returns true for exactly one caller: the first to reach
-// it. Every state path (the D-Bus event reconciler, the reconnect resync, and the
-// start/delete helpers) funnels an exit through SetState, but the resulting
-// TaskExit must be emitted only once no matter how many of them observe the exit
-// concurrently. Callers gate emission on st.Exited() && p.claimExitNotification().
-func (p *process) claimExitNotification() bool {
+// advanceLocked moves the process into phase next, rejecting any transition
+// phaseTransitions does not list. A rejection leaves the phase untouched and
+// reports an invalidTransitionError; it never panics or forces the move, because
+// most rejections are races the shim is expected to survive -- a unit event
+// arriving after a delete, or a start losing to the exit it was starting.
+//
+// It reports whether the phase actually changed, which is what makes an exit
+// observable exactly once: only one caller can be the one that moves a process
+// into phaseExited.
+//
+// p.mu must be held.
+func (p *process) advanceLocked(next procPhase) (changed bool, err error) {
+	if !p.phase.canBecome(next) {
+		return false, invalidTransitionError{from: p.phase, to: next}
+	}
+	if p.phase == next {
+		return false, nil
+	}
+	p.phase = next
+	return true, nil
+}
+
+// advance moves the process into phase next and wakes anything waiting on its
+// state. It reports whether the phase actually changed, so a caller can act on a
+// transition exactly once.
+func (p *process) advance(next procPhase) (bool, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.exitNotified {
-		return false
-	}
-	p.exitNotified = true
-	return true
+	changed, err := p.advanceLocked(next)
+	p.cond.Broadcast()
+	return changed, err
 }
 
-func (p *process) sendExitAfterStart(send func()) {
-	p.eventMu.Lock()
-	if !p.startEventPublished {
-		p.pendingExitEvent = send
-		p.eventMu.Unlock()
-		return
-	}
-	p.eventMu.Unlock()
-	send()
+func (p *process) currentPhase() procPhase {
+	p.mu.Lock()
+	phase := p.phase
+	p.mu.Unlock()
+	return phase
 }
 
-func (p *process) markStartEventPublished() {
-	p.eventMu.Lock()
-	p.startEventPublished = true
-	send := p.pendingExitEvent
-	p.pendingExitEvent = nil
-	p.eventMu.Unlock()
-	if send != nil {
-		send()
+// beginStart claims the process for a start attempt. It is the gate that makes
+// an already-exited or already-deleted process impossible to start, and it runs
+// before Start does any work so a rejected start never reaches runc. Only one
+// attempt may hold the claim: a second concurrent Start is rejected rather than
+// admitted alongside the first, whose unit it would otherwise tear down when its
+// own runc start failed. Its counterparts are abortStart and
+// initProcess/execProcess.finishStart.
+func (p *process) beginStart() error {
+	_, err := p.advance(phaseStarting)
+	return err
+}
+
+// abortStart hands the claim back after a failed attempt so another can be made.
+// It is a no-op once something else has moved the phase on -- the workload
+// exited during the attempt, or a delete tore the process down -- because
+// neither is a state a retry could start from.
+func (p *process) abortStart(ctx context.Context) {
+	if _, err := p.advance(phaseCreated); err != nil {
+		log.G(ctx).WithError(err).WithField("id", p.id).Debug("Failed start attempt ended in a terminal phase")
 	}
 }
 
@@ -306,25 +335,58 @@ func (p *process) ProcessState() pState {
 	return st
 }
 
-func (p *process) SetState(ctx context.Context, state pState) pState {
+// stateUpdate is the outcome of merging one observation into a process: the
+// resulting state and the lifecycle transition, if any, that it caused.
+type stateUpdate struct {
+	state    pState
+	from, to procPhase
+}
+
+// justExited reports whether this update is the one that ended the process.
+// Every state path -- the D-Bus event reconciler, the reconnect resync, and the
+// start/delete helpers -- funnels an exit through SetState, but the resulting
+// TaskExit must be emitted only once no matter how many of them observe the exit
+// concurrently. Only one caller can move a process into phaseExited, so this
+// answer is the exactly-once guarantee rather than a flag alongside it.
+func (u stateUpdate) justExited() bool {
+	return u.to == phaseExited && u.from != u.to
+}
+
+// wasRunning reports whether the process was running before this update.
+func (u stateUpdate) wasRunning() bool {
+	return u.from == phaseRunning
+}
+
+// applyState merges an observation into the process and advances the lifecycle
+// if the result is terminal. The merge and the transition happen under one lock
+// so no caller can see a terminal state that has not yet moved the phase.
+func (p *process) applyState(ctx context.Context, state pState) stateUpdate {
 	p.mu.Lock()
-	if !p.started && toStatus(state.Status) == task.Status_RUNNING {
+	defer p.mu.Unlock()
+
+	from := p.phase
+	// systemd reports a unit as running as soon as `runc create` has the
+	// container set up, which is still created as far as containerd is concerned.
+	// The phase, not the observation, decides which of the two this is.
+	if p.phase < phaseRunning && toStatus(state.Status) == task.Status_RUNNING {
 		state.Status = "created"
 	}
 	state.CopyTo(&p.state)
 	if p.state.ExitCode > 0 && !p.state.Exited() {
 		p.state.ExitedAt = time.Now()
 	}
+	if p.state.Exited() {
+		if _, err := p.advanceLocked(phaseExited); err != nil {
+			log.G(ctx).WithError(err).WithField("id", p.id).Debug("Ignoring exit observed after delete")
+		}
+	}
 	p.state.CopyTo(&state)
 	p.cond.Broadcast()
-	p.mu.Unlock()
-	return state
+	return stateUpdate{state: state, from: from, to: p.phase}
 }
 
-func (p *process) markStarted() {
-	p.mu.Lock()
-	p.started = true
-	p.mu.Unlock()
+func (p *process) SetState(ctx context.Context, state pState) pState {
+	return p.applyState(ctx, state).state
 }
 
 // markDeleting records that teardown has begun, before any of it runs. A start
@@ -333,8 +395,13 @@ func (p *process) markStarted() {
 // teardown tears it down, or it did not and the starter sees the flag and
 // abandons it. Without that, a delete could untrack the process just before a
 // start created its unit, stranding a running, referenced unit that nothing
-// would ever release. It is distinct from deleted, which is set only once
-// teardown finishes because waitForExit uses it to stop waiting.
+// would ever release.
+//
+// It is a flag rather than a phase because teardown is orthogonal to the
+// lifecycle: it begins while the process may still be running and must still be
+// able to observe that process exit, so a deleting phase would need edges both
+// to and from phaseExited. phaseDeleted, which teardown reaches only once it has
+// finished, is the phase half of the same story.
 func (p *process) markDeleting() {
 	p.mu.Lock()
 	p.deleting = true
@@ -346,13 +413,6 @@ func (p *process) isDeleting() bool {
 	deleting := p.deleting
 	p.mu.Unlock()
 	return deleting
-}
-
-func (p *process) hasStarted() bool {
-	p.mu.Lock()
-	started := p.started
-	p.mu.Unlock()
-	return started
 }
 
 func (p *execProcess) Name() string {
@@ -442,8 +502,7 @@ type initProcess struct {
 
 	execs *processManager
 
-	sendEvent func(ctx context.Context, ns string, evt interface{})
-	shimLog   io.Writer
+	shimLog io.Writer
 }
 
 func (p *initProcess) LogWriter() io.Writer {
@@ -454,10 +513,47 @@ func (p *initProcess) pidFile() string {
 	return filepath.Join(p.root, "init.pid")
 }
 
+// finishStart completes a successful Start: it finishes the lifecycle
+// transition beginStart claimed, records the running state, and publishes the
+// task's start. A workload that died while Start was in flight rejects the
+// transition, but its start is still published -- containerd needs it before the
+// exit the outbox is already holding.
+func (p *initProcess) finishStart(ctx context.Context, pid uint32) {
+	if _, err := p.advance(phaseRunning); err != nil {
+		log.G(ctx).WithError(err).Debug("Container exited while it was starting")
+	}
+	p.SetState(ctx, pState{Pid: pid, Status: "running"})
+	p.events.Send(ctx, &eventsapi.TaskStart{
+		ContainerID: p.id,
+		Pid:         pid,
+	})
+}
+
+// finishDelete records that teardown finished -- waking waitForExit for a
+// process that will never report an exit of its own -- and publishes the task's
+// delete. Nothing may follow it.
+func (p *initProcess) finishDelete(ctx context.Context) {
+	deleted, err := p.advance(phaseDeleted)
+	if err != nil {
+		log.G(ctx).WithError(err).WithField("id", p.id).Debug("Ignoring delete of an already deleted container")
+	}
+	if !deleted {
+		return
+	}
+	st := p.ProcessState()
+	p.events.Send(ctx, &eventsapi.TaskDelete{
+		ContainerID: p.id,
+		Pid:         st.Pid,
+		ExitStatus:  st.ExitCode,
+		ExitedAt:    timestamppb.New(st.ExitedAt),
+	})
+}
+
 func (p *initProcess) SetState(ctx context.Context, state pState) pState {
-	st := p.process.SetState(ctx, state)
-	if st.Exited() && p.claimExitNotification() {
-		if st.Status != exitedInit && p.hasStarted() && p.killAllOnExit {
+	u := p.applyState(ctx, state)
+	st := u.state
+	if u.justExited() {
+		if st.Status != exitedInit && u.wasRunning() && p.killAllOnExit {
 			if err := p.runc.Kill(ctx, p.id, int(syscall.SIGKILL), &runc.KillOpts{All: true}); err != nil {
 				log.G(ctx).WithError(err).WithField("id", p.id).Error("failed to kill init's children")
 			}
@@ -470,7 +566,7 @@ func (p *initProcess) SetState(ctx context.Context, state pState) pState {
 			// An exec that never started has no process to reap. Leave it in its
 			// Created state so callers see it never ran, rather than synthesizing
 			// a non-zero exit for a process that was only ever set up.
-			if ep, ok := exec.(*execProcess); ok && !ep.hasStarted() {
+			if ep, ok := exec.(*execProcess); ok && ep.currentPhase() < phaseRunning {
 				return
 			}
 			if !exec.ProcessState().Exited() {
@@ -480,14 +576,12 @@ func (p *initProcess) SetState(ctx context.Context, state pState) pState {
 		p.cond.Broadcast()
 		// If the init helper process exited, this should not yield a task exit event as the task never actually started.
 		if st.Status != exitedInit {
-			p.sendExitAfterStart(func() {
-				p.sendEvent(ctx, p.ns, &eventsapi.TaskExit{
-					ContainerID: p.id,
-					ID:          p.id,
-					ExitStatus:  st.ExitCode,
-					ExitedAt:    timestamppb.New(st.ExitedAt),
-					Pid:         st.Pid,
-				})
+			p.events.Send(ctx, &eventsapi.TaskExit{
+				ContainerID: p.id,
+				ID:          p.id,
+				ExitStatus:  st.ExitCode,
+				ExitedAt:    timestamppb.New(st.ExitedAt),
+				Pid:         st.Pid,
 			})
 		}
 	}
@@ -602,18 +696,39 @@ func (p *execProcess) getPid(context.Context) (uint32, error) {
 	return uint32(pid), nil
 }
 
+// finishStart mirrors initProcess.finishStart for an exec process.
+func (p *execProcess) finishStart(ctx context.Context, pid uint32) {
+	if _, err := p.advance(phaseRunning); err != nil {
+		log.G(ctx).WithError(err).Debug("Exec exited while it was starting")
+	}
+	p.SetState(ctx, pState{Pid: pid, Status: "running"})
+	p.events.Send(ctx, &eventsapi.TaskExecStarted{
+		ContainerID: p.parent.id,
+		ExecID:      p.execID,
+		Pid:         pid,
+	})
+}
+
+// finishDelete mirrors initProcess.finishDelete. An exec publishes no delete
+// event -- containerd's runc shim does not either -- so this only ends the
+// lifecycle.
+func (p *execProcess) finishDelete(ctx context.Context) {
+	if _, err := p.advance(phaseDeleted); err != nil {
+		log.G(ctx).WithError(err).WithField("id", p.id).Debug("Ignoring delete of an already deleted exec")
+	}
+}
+
 func (p *execProcess) SetState(ctx context.Context, state pState) pState {
-	st := p.process.SetState(ctx, state)
-	if st.Exited() && p.claimExitNotification() {
+	u := p.applyState(ctx, state)
+	st := u.state
+	if u.justExited() {
 		p.cond.Broadcast()
-		p.sendExitAfterStart(func() {
-			p.parent.sendEvent(ctx, p.ns, &eventsapi.TaskExit{
-				ContainerID: p.parent.id,
-				ID:          p.execID,
-				ExitStatus:  st.ExitCode,
-				ExitedAt:    timestamppb.New(st.ExitedAt),
-				Pid:         st.Pid,
-			})
+		p.events.Send(ctx, &eventsapi.TaskExit{
+			ContainerID: p.parent.id,
+			ID:          p.execID,
+			ExitStatus:  st.ExitCode,
+			ExitedAt:    timestamppb.New(st.ExitedAt),
+			Pid:         st.Pid,
 		})
 	}
 	return st

--- a/process_test.go
+++ b/process_test.go
@@ -27,7 +27,17 @@ func TestProcessLifecycleStatus(t *testing.T) {
 			t.Fatalf("status before Start = %q, want created", state.Status)
 		}
 
-		p.markStarted()
+		if err := p.beginStart(); err != nil {
+			t.Fatalf("begin start: %v", err)
+		}
+		state = p.SetState(context.Background(), pState{Pid: 42, Status: "running"})
+		if state.Status != "created" {
+			t.Fatalf("status while Start is in flight = %q, want created", state.Status)
+		}
+
+		if _, err := p.advance(phaseRunning); err != nil {
+			t.Fatalf("finish start: %v", err)
+		}
 		state = p.SetState(context.Background(), pState{Pid: 42, Status: "running"})
 		if state.Status != "running" {
 			t.Fatalf("status after Start = %q, want running", state.Status)
@@ -37,7 +47,7 @@ func TestProcessLifecycleStatus(t *testing.T) {
 	t.Run("a recorded exit is not overwritten by a later non-terminal update", func(t *testing.T) {
 		p := &process{}
 		p.cond = sync.NewCond(&p.mu)
-		p.markStarted()
+		runTestProcess(t, p)
 
 		p.SetState(context.Background(), pState{Pid: 42, ExitCode: 9, Status: "exited", ExitedAt: time.Now()})
 
@@ -53,7 +63,7 @@ func TestProcessLifecycleStatus(t *testing.T) {
 	t.Run("a recorded exit can be refined by a later terminal update", func(t *testing.T) {
 		p := &process{}
 		p.cond = sync.NewCond(&p.mu)
-		p.markStarted()
+		runTestProcess(t, p)
 
 		p.SetState(context.Background(), pState{Pid: 42, Status: "exited", ExitedAt: time.Now()})
 
@@ -166,7 +176,7 @@ func TestInitExitCleanup(t *testing.T) {
 		p.root = t.TempDir()
 		p.runc = &runc.Runc{Command: runcPath, Root: runcRoot}
 		p.killAllOnExit = true
-		p.markStarted()
+		runTestProcess(t, p.process)
 
 		p.SetState(context.Background(), pState{
 			Pid:      42,
@@ -302,7 +312,7 @@ func TestExecStatusWhenInitExits(t *testing.T) {
 	t.Run("an init exit reaps a started exec", func(t *testing.T) {
 		parent, _ := newTestInitProcess("c-started")
 		ep := newTestExecProcess(parent, "exec1")
-		ep.markStarted()
+		runTestProcess(t, ep.process)
 		ep.SetState(context.Background(), pState{Pid: 99, Status: "running"})
 		if err := parent.execs.Add("exec1", ep); err != nil {
 			t.Fatalf("register exec: %v", err)
@@ -339,35 +349,51 @@ func TestExecStatusWhenInitExits(t *testing.T) {
 	})
 }
 
-// --- helpers ---
+// runTestProcess moves p through the lifecycle a successful Start would: it
+// claims the start and then completes it.
+func runTestProcess(t *testing.T, p *process) {
+	t.Helper()
+	if err := p.beginStart(); err != nil {
+		t.Fatalf("begin start: %v", err)
+	}
+	if _, err := p.advance(phaseRunning); err != nil {
+		t.Fatalf("finish start: %v", err)
+	}
+}
 
 // newTestInitProcess builds an initProcess wired with a TaskExit counter. The
-// returned func reports how many TaskExit events have been emitted so far.
+// returned func reports how many TaskExit events have been emitted so far. Its
+// start has already gone out, so exits publish immediately rather than being
+// held by the outbox.
 func newTestInitProcess(id string) (*initProcess, func() int32) {
 	var taskExits int32
+	send := func(_ context.Context, _ string, evt interface{}) bool {
+		if _, ok := evt.(*eventsapi.TaskExit); ok {
+			atomic.AddInt32(&taskExits, 1)
+		}
+		return true
+	}
 	p := &initProcess{
-		process: &process{ns: "testns", id: id},
+		process: &process{ns: "testns", id: id, events: newEventOutbox("testns", send)},
 		execs:   &processManager{ls: make(map[string]Process)},
 		shimLog: io.Discard,
-		sendEvent: func(_ context.Context, _ string, evt interface{}) {
-			if _, ok := evt.(*eventsapi.TaskExit); ok {
-				atomic.AddInt32(&taskExits, 1)
-			}
-		},
 	}
 	p.cond = sync.NewCond(&p.mu)
-	p.markStartEventPublished()
+	p.events.Send(context.Background(), &eventsapi.TaskStart{ContainerID: id})
 	return p, func() int32 { return atomic.LoadInt32(&taskExits) }
 }
 
+// newTestExecProcess builds an exec with its own outbox feeding the parent's
+// event sink, as Service.Exec does, so the parent's TaskExit counter sees the
+// exec's exits. Its start has already gone out.
 func newTestExecProcess(parent *initProcess, execID string) *execProcess {
 	ep := &execProcess{
-		process: &process{ns: parent.ns, id: execID},
+		process: &process{ns: parent.ns, id: execID, events: newEventOutbox(parent.ns, parent.events.send)},
 		parent:  parent,
 		execID:  execID,
 	}
 	ep.cond = sync.NewCond(&ep.mu)
-	ep.markStartEventPublished()
+	ep.events.Send(context.Background(), &eventsapi.TaskExecStarted{ExecID: execID})
 	return ep
 }
 

--- a/start.go
+++ b/start.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"time"
 
-	eventsapi "github.com/containerd/containerd/api/events"
 	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
 	"github.com/containerd/containerd/v2/pkg/namespaces"
 	"github.com/containerd/errdefs"
@@ -61,26 +60,13 @@ func (s *Service) Start(ctx context.Context, r *taskapi.StartRequest) (_ *taskap
 			s.units.Delete(ep)
 			return nil, err
 		}
-		ep.(*execProcess).markStarted()
-		ep.SetState(ctx, pState{Pid: pid, Status: "running"})
-		s.send(ctx, ns, &eventsapi.TaskExecStarted{
-			ContainerID: r.ID,
-			ExecID:      r.ExecID,
-			Pid:         pid,
-		})
-		ep.(*execProcess).markStartEventPublished()
+		ep.(*execProcess).finishStart(ctx, pid)
 	} else {
 		pid, err = p.Start(ctx)
 		if err != nil {
 			return nil, err
 		}
-		p.(*initProcess).markStarted()
-		p.SetState(ctx, pState{Pid: pid, Status: "running"})
-		s.send(ctx, ns, &eventsapi.TaskStart{
-			ContainerID: r.ID,
-			Pid:         pid,
-		})
-		p.(*initProcess).markStartEventPublished()
+		p.(*initProcess).finishStart(ctx, pid)
 	}
 
 	return &taskapi.StartResponse{Pid: pid}, nil
@@ -278,12 +264,20 @@ func (p *initProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 		span.End()
 	}()
 
+	// Claim the process for this start before touching runc or systemd, so a
+	// process that has already exited (or been deleted, or is already being
+	// started) is refused rather than half-started.
+	if err := p.beginStart(); err != nil {
+		return 0, fmt.Errorf("start container: %w: %s", err, p.ProcessState())
+	}
+	defer func() {
+		if retErr != nil {
+			p.abortStart(ctx)
+		}
+	}()
+
 	if p.checkpoint != "" {
 		return p.restore(ctx)
-	}
-
-	if p.ProcessState().Exited() {
-		return 0, fmt.Errorf("process has already exited: %s: %w", p.ProcessState(), errdefs.ErrFailedPrecondition)
 	}
 
 	if err := p.runc.Start(ctx, p.id); err != nil {
@@ -384,6 +378,18 @@ func (p *initProcess) restore(ctx context.Context) (pid uint32, retErr error) {
 }
 
 func (p *execProcess) Start(ctx context.Context) (pid uint32, retErr error) {
+	// See the note in initProcess.Start: the lifecycle claim comes first so an
+	// exec that already exited, or is already being started, cannot be started
+	// again.
+	if err := p.beginStart(); err != nil {
+		return 0, fmt.Errorf("start exec: %w: %s", err, p.ProcessState())
+	}
+	defer func() {
+		if retErr != nil {
+			p.abortStart(ctx)
+		}
+	}()
+
 	if !p.parent.ProcessState().Started() {
 		p.parent.LoadState(ctx)
 		if !p.parent.ProcessState().Started() {

--- a/state.go
+++ b/state.go
@@ -275,7 +275,7 @@ func (p *execProcess) State(ctx context.Context) (*State, error) {
 
 	p.mu.Lock()
 	p.state.CopyTo(&st.State)
-	started := p.started
+	beforeRunning := p.phase < phaseRunning
 	p.mu.Unlock()
 
 	// An exec reports Created until its process actually runs. If the
@@ -284,7 +284,7 @@ func (p *execProcess) State(ctx context.Context) (*State, error) {
 	// report Created rather than a synthetic exit. An exec that was set up but
 	// never started likewise has no recorded state.
 	initDied := st.State.Status == exitedInit && p.parent.ProcessState().Exited()
-	if initDied || (!started && !st.State.Exited()) {
+	if initDied || (beforeRunning && !st.State.Exited()) {
 		st.State.Status = "created"
 		st.State.ExitCode = 0
 		st.State.ExitedAt = timeZero

--- a/state_recorded_exit_test.go
+++ b/state_recorded_exit_test.go
@@ -9,8 +9,8 @@ import (
 
 func TestLoadExitStateUsesRecordedSystemdState(t *testing.T) {
 	t.Run("an exec exit remains available after its systemd unit unloads", func(t *testing.T) {
-		parent := &initProcess{process: &process{id: "task"}}
-		process := &process{id: "exec"}
+		parent := &initProcess{process: &process{id: "task", events: discardEvents()}}
+		process := &process{id: "exec", events: discardEvents()}
 		process.cond = sync.NewCond(&process.mu)
 		exec := &execProcess{
 			process: process,
@@ -36,8 +36,8 @@ func TestLoadExitStateUsesRecordedSystemdState(t *testing.T) {
 	})
 
 	t.Run("a later service exit supersedes an earlier terminal signal", func(t *testing.T) {
-		parent := &initProcess{process: &process{id: "task"}}
-		process := &process{id: "exec"}
+		parent := &initProcess{process: &process{id: "task", events: discardEvents()}}
+		process := &process{id: "exec", events: discardEvents()}
 		process.cond = sync.NewCond(&process.mu)
 		exec := &execProcess{
 			process: process,

--- a/unitevents_test.go
+++ b/unitevents_test.go
@@ -664,8 +664,6 @@ func TestEventReactorResync(t *testing.T) {
 	})
 }
 
-// --- helpers ---
-
 // eventually polls cond until it returns true or timeout elapses, sleeping step
 // between checks. It returns true as soon as cond passes, so a passing check
 // returns promptly; only a failing check runs to the full deadline.

--- a/wait.go
+++ b/wait.go
@@ -102,7 +102,7 @@ func (p *process) waitForExit(ctx context.Context) (pState, error) {
 		default:
 		}
 
-		if p.deleted {
+		if p.phase == phaseDeleted {
 			log.G(ctx).Debug("wait: deleted")
 			break
 		}


### PR DESCRIPTION
A process's lifecycle was spread across four independent flags (`started`,
`deleted`, `deleting`, `exitNotified`) plus a free-form systemd substatus
string, with the rules about what may follow what left implicit in
`pState.CopyTo` and open-coded checks at the call sites. An exec could be
started after it had exited, and the exactly-once `TaskExit` guarantee rested
on a flag that was only coincidentally in step with the state.

## The machine

An explicit phase, with one table that is the whole lifecycle:

```go
var phaseTransitions = map[procPhase][]procPhase{
	phaseCreated:  {phaseCreated, phaseStarting, phaseExited, phaseDeleted},
	phaseStarting: {phaseCreated, phaseRunning, phaseExited, phaseDeleted},
	phaseRunning:  {phaseRunning, phaseExited, phaseDeleted},
	phaseExited:   {phaseExited, phaseDeleted},
	phaseDeleted:  {phaseDeleted},
}
```

Rejections unwrap to `errdefs.ErrFailedPrecondition`, so they reach containerd
with the right gRPC status unmapped.

`starting` is a claim rather than an observation, so it is the one phase that
cannot repeat, and `Start` claims it before touching runc. That closes a real
hole: two concurrent `Start`s were both admitted, and the loser's `runc start`
failure path SIGKILLs the unit when the process is still running — killing the
container the winner had just started successfully. A failed attempt hands the
claim back (`starting -> created`) so a retry is still possible.

The transition into `exited` is now the exactly-once guarantee — only one caller
can make it — replacing `exitNotified`/`claimExitNotification`.

## Events

Every event that corresponds to a transition now comes from that transition,
through a per-process outbox. Each event carries a precondition, re-checked on
every send rather than assuming one arrival releases everything held:

- an exit waits for its start (the reactor can see a workload die while `Start`
  is still running, so the exit is observed first)
- a delete waits for its create (a failed `Create` tears down through the same
  path and must not report the end of a task containerd never saw begin)
- nothing follows a delete

This replaces a bespoke deferral of the exit event alone. It also publishes
`TaskDelete`, which had a topic in `GetTopic` but was never constructed anywhere
— containerd's own runc v2 shim sends it for init tasks.

Publishing is bound to the shim's lifetime rather than the calling RPC: an event
records something that already happened, so a client giving up must not stop
containerd hearing about it, while a shim shutting down or a publish timeout
still ends the wait.

## Testing

`go test -race ./...` including the live systemd integration tests. The
lifecycle and ordering rules are covered directly in `phase_test.go` and
`events_test.go`.

## Known gaps, not addressed here

- A stalled publish is retained for the next `Send` on that process, and
  `TaskDelete` has no next send, so a delete that times out is lost. Needs
  something that re-drives the queue.
- A `send` parked on a full queue when `Close` runs would send on a closed
  channel. Pre-existing; narrowed by binding the wait to the shim context, not
  closed.
- `TaskPaused`/`TaskResumed` are still never published and `paused` is not a
  phase, though `toStatus` already maps `PAUSING`/`PAUSED`. Pause is invisible
  to systemd (a cgroup freezer operation), so it would be the first phase with
  no observation behind it.
