### PR TITLE
Take the workload's exit status from a single wait

### DIFF
--- a/create.go
+++ b/create.go
@@ -3,17 +3,17 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -621,36 +621,6 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 	return handlePid()
 }
 
-type waitStatus struct {
-	Status int
-	Err    error
-	Pid    uint32
-}
-
-func waitAny(ws *unix.WaitStatus) (int, error) {
-	for {
-		pid, err := unix.Wait4(-1, ws, unix.WNOHANG, nil)
-		if err != unix.EINTR {
-			return pid, err
-		}
-	}
-}
-
-func reap(ctx context.Context, chChld chan os.Signal, wait chan waitStatus) {
-	for range chChld {
-		var ws unix.WaitStatus
-
-		pid, err := waitAny(&ws)
-		if pid <= 0 {
-			log.G(ctx).WithError(err).WithField("pid", pid).Warn("Error waiting for child")
-			continue
-		}
-
-		wait <- waitStatus{Status: ws.ExitStatus(), Pid: uint32(pid)}
-		return
-	}
-}
-
 func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap bool) (retErr error) {
 	log.G(ctx).Debugf("%s %s", cmdLine[0], cmdLine[1:])
 
@@ -721,14 +691,11 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 		log.G(ctx).Debug("No stderr pipe")
 	}
 
-	wait := make(chan waitStatus, 1)
-	chChld := make(chan os.Signal, 1)
-	defer signal.Stop(chChld)
-
-	var readPid uint32
 	if !noReap {
-		signal.Notify(chChld, syscall.SIGCHLD)
-
+		// runc detaches, so it exits 0 as soon as the workload is started and its
+		// own status says nothing about the workload. Become the workload's
+		// subreaper so that if it exits before systemd is told about it, its status
+		// is delivered here rather than to a parent that will discard it.
 		var i uintptr = 1
 		if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, i, 0, 0, 0); err != nil {
 			log.G(ctx).WithError(err).Error("failed to set child subreaper")
@@ -740,47 +707,6 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 	}
 
 	log.G(ctx).Debugf("runc pid: %d", cmd.Process.Pid)
-
-	chPid := make(chan int)
-	go func() {
-		pidFile := os.Getenv("PIDFILE")
-		for {
-			done := func() bool {
-				_, err := os.Stat(pidFile)
-				if err != nil {
-					return false
-				}
-
-				f, err := os.Open(pidFile)
-				if err != nil {
-					log.G(ctx).WithError(err).Debug("Error opening pidfile")
-					return false
-				}
-				defer f.Close()
-
-				pidData, err := ioutil.ReadAll(f)
-				if err != nil {
-					log.G(ctx).WithError(err).Debug("Error reading pidfile")
-					return false
-				}
-
-				pid, err := strconv.Atoi(strings.TrimSpace(string(pidData)))
-				if err != nil {
-					log.G(ctx).WithError(err).Debug("Error parsing pidfile")
-					return false
-				}
-
-				atomic.StoreUint32(&readPid, uint32(pid))
-				chPid <- pid
-				return true
-			}()
-
-			if done {
-				return
-			}
-			<-time.After(100 * time.Millisecond)
-		}
-	}()
 
 	var st pState
 
@@ -820,67 +746,132 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 		sdNotify(ctx, notifyErrno(st.ExitCode), notifyStatus(st.Status))
 		return err
 	}
-	if !noReap {
-		// Cmd.Wait is the sole waiter for runc. Start the subreaper only after it
-		// returns so wait4 cannot consume runc's status first.
-		go reap(ctx, chChld, wait)
+
+	// runc detaches, so it has written the pid of the process it left behind
+	// before exiting.
+	pid, err := readPidFile(ctx, os.Getenv("PIDFILE"))
+	if err != nil {
+		return err
 	}
 
-	var notify func()
-
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case status := <-wait:
-		st.ExitCode = uint32(status.Status)
-		st.ExitedAt = time.Now()
-		st.Pid = status.Pid
-		st.Status = "exited"
-		notify = func() { sdNotify(ctx, notifyErrno(st.ExitCode), notifyStatus(st.Status), notifyMainPID(st.Pid)) }
-	case pid := <-chPid:
-		st.Pid = uint32(pid)
-		if !noReap {
-			// At this point we have the pid, so we can turn off the subreaper and call wait4 ourselves
-			// to make sure the process did not exit in the meantime.
-			var i uintptr = 0
-			if err := unix.Prctl(unix.PR_SET_CHILD_SUBREAPER, i, 0, 0, 0); err != nil {
-				log.G(ctx).WithError(err).Error("failed to unset child subreaper")
-			}
-
-			select {
-			case status := <-wait:
-				// Looks like we did reap the process, so use this status.
-				st.Pid = status.Pid
-				st.ExitCode = uint32(status.Status)
-				st.ExitedAt = time.Now()
-				st.Status = "exited"
-				notify = func() { sdNotify(ctx, notifyStatus(st.Status), notifyErrno(st.ExitCode), notifyMainPID(st.Pid)) }
-			default:
-				var status unix.WaitStatus
-				// Double check if the process is still running.
-				p, _ := unix.Wait4(pid, &status, unix.WNOHANG, nil)
-				if p == pid {
-					st.ExitCode = uint32(status.ExitStatus())
-					st.ExitedAt = time.Now()
-					st.Status = "exited"
-					notify = func() { sdNotify(ctx, notifyStatus(st.Status), notifyErrno(st.ExitCode), notifyMainPID(st.Pid)) }
-				} else {
-					st.Status = "running"
-					notify = func() {
-						sdNotify(ctx, daemon.SdNotifyReady, notifyMainPID(st.Pid))
-						log.G(ctx).Debug("Process is up!")
-					}
-				}
-			}
-
+	st = pState{Pid: uint32(pid)}
+	if !noReap {
+		if st, err = workloadState(pid); err != nil {
+			return err
 		}
 	}
 
-	err := writeFile()
-	if notify != nil {
-		notify()
+	if err := writeFile(); err != nil {
+		return err
 	}
-	return err
+	notifyWorkload(ctx, st)
+
+	if st.Status != "running" {
+		return nil
+	}
+
+	// sd_notify is a datagram with no reply, so the handoff above is not yet a
+	// fact. Wait for systemd to have processed it, then look once more: systemd
+	// refuses a main pid that has already become a zombie, so a workload that
+	// died while the handoff was in flight is still this process' to report.
+	if err := sdNotifyBarrier(ctx); err != nil {
+		// Without the barrier there is no ordering guarantee, but the re-check
+		// below is what actually recovers a workload that died during the
+		// handoff. Skipping it because the barrier failed would leave that exit
+		// reported by nobody, which is the failure this whole path exists for.
+		log.G(ctx).WithError(err).Warn("Error waiting for systemd to take the main pid; re-checking anyway")
+	}
+	if st, err = workloadState(pid); err != nil {
+		log.G(ctx).WithError(err).Warn("Error re-checking the workload after handoff")
+		return nil
+	}
+	if st.Status == "running" {
+		// systemd has the pid and the pid is alive, so systemd owns its exit.
+		return nil
+	}
+	if err := writeFile(); err != nil {
+		return err
+	}
+	notifyWorkload(ctx, st)
+	return nil
+}
+
+// pidFileTimeout bounds the wait for runc's pid file. runc writes it before it
+// exits, so this only covers a write that has not landed yet.
+const pidFileTimeout = 5 * time.Second
+
+// readPidFile reads the pid runc recorded for the process it left behind.
+func readPidFile(ctx context.Context, path string) (int, error) {
+	deadline := time.Now().Add(pidFileTimeout)
+	for {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			var pid int
+			if pid, err = strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
+				return pid, nil
+			}
+			err = fmt.Errorf("invalid pid in %s: %w", path, err)
+		}
+
+		if time.Now().After(deadline) {
+			return 0, err
+		}
+		select {
+		case <-ctx.Done():
+			return 0, ctx.Err()
+		case <-time.After(10 * time.Millisecond):
+		}
+	}
+}
+
+// workloadState reports the state of the process runc left behind: whether it
+// has already exited, and with what status.
+//
+// This is the only wait4 this process makes. runc always exits 0 once it has
+// detached, so its status says nothing about the workload; the workload was
+// reparented here when runc exited -- this process is its subreaper -- so while
+// it is a child here its exit status is delivered here and nowhere else.
+//
+// A workload that is still running belongs to systemd instead, and must not be
+// waited on again: systemd inherits it when this process exits and reports its
+// exit status, which a later wait4 here would consume and throw away.
+func workloadState(pid int) (pState, error) {
+	var ws unix.WaitStatus
+	reaped, err := unix.Wait4(pid, &ws, unix.WNOHANG, nil)
+	if err != nil {
+		// ECHILD included: the workload is not this process' child, so nothing
+		// here can say whether it ran or what it returned, and reporting that as
+		// an exit status of 0 is the failure worth avoiding.
+		return pState{}, fmt.Errorf("error checking on process %d: %w", pid, err)
+	}
+	if reaped != pid {
+		return pState{Pid: uint32(pid), Status: "running"}, nil
+	}
+
+	st := pState{
+		Pid:      uint32(pid),
+		ExitCode: uint32(ws.ExitStatus()),
+		ExitedAt: time.Now(),
+		Status:   "exited",
+	}
+	if ws.Signaled() {
+		// A killed workload has no exit code. containerd reports termination by
+		// signal as 128+signal (see its reaper's exitStatus), which is what its
+		// clients render as e.g. 137 for SIGKILL, so report the same here rather
+		// than the bare signal number systemd puts in ExecMainStatus.
+		st.ExitCode = uint32(exitSignalOffset + int(ws.Signal()))
+	}
+	return st, nil
+}
+
+func notifyWorkload(ctx context.Context, st pState) {
+	switch st.Status {
+	case "exited":
+		sdNotify(ctx, notifyStatus(st.Status), notifyErrno(st.ExitCode), notifyMainPID(st.Pid))
+	case "running":
+		sdNotify(ctx, daemon.SdNotifyReady, notifyMainPID(st.Pid))
+		log.G(ctx).Debug("Process is up!")
+	}
 }
 
 func shouldKillAllOnExit(spec *specs.Spec) bool {
@@ -910,6 +901,59 @@ func sdNotify(ctx context.Context, status ...string) {
 	if _, err := daemon.SdNotify(false, strings.Join(status, "\n")); err != nil {
 		log.G(ctx).WithError(err).Error("failed to notify systemd")
 	}
+}
+
+// notifyBarrierTimeout bounds the wait for systemd to catch up on this process'
+// notifications. It only has to cover systemd getting round to a queued
+// datagram; a manager too busy for that is a manager whose answer would be stale
+// anyway.
+const notifyBarrierTimeout = 5 * time.Second
+
+// sdNotifyBarrier blocks until systemd has processed every notification this
+// process has sent, implementing sd_notify(3)'s BARRIER=1.
+//
+// A notification is a datagram with no reply, so sending one says nothing about
+// whether systemd has acted on it. systemd holds the pipe end passed here until
+// it has drained everything queued ahead of it, so reading EOF means the earlier
+// notifications have been handled.
+func sdNotifyBarrier(ctx context.Context) error {
+	addr := os.Getenv("NOTIFY_SOCKET")
+	if addr == "" {
+		return nil
+	}
+
+	fd, err := unix.Socket(unix.AF_UNIX, unix.SOCK_DGRAM|unix.SOCK_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("error opening notify socket: %w", err)
+	}
+	defer unix.Close(fd)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	// A leading '@' is how systemd advertises an abstract socket, which is what
+	// SockaddrUnix takes it to mean too.
+	err = unix.Sendmsg(fd, []byte("BARRIER=1"), unix.UnixRights(int(w.Fd())), &unix.SockaddrUnix{Name: addr}, 0)
+	// Only systemd's copy of the write end may keep the pipe open.
+	w.Close()
+	if err != nil {
+		return fmt.Errorf("error sending notify barrier: %w", err)
+	}
+
+	deadline := time.Now().Add(notifyBarrierTimeout)
+	if end, ok := ctx.Deadline(); ok && end.Before(deadline) {
+		deadline = end
+	}
+	if err := r.SetReadDeadline(deadline); err != nil {
+		return err
+	}
+	if _, err := r.Read(make([]byte, 1)); err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("error waiting on notify barrier: %w", err)
+	}
+	return nil
 }
 
 type cgMode cgroups.CGMode

--- a/create_test.go
+++ b/create_test.go
@@ -147,9 +147,29 @@ func startTestChild(t *testing.T, cfg runcStubConfig) int {
 	return pid
 }
 
+// waitForTestChildExit blocks until the child is reapable, without reaping it --
+// that is the job of the code under test. A zombie main thread is not enough:
+// the helper is this test binary re-executed, so it is multi-threaded, and
+// /proc/<pid>/stat reports Z while the rest of the thread group is still exiting
+// even though wait4 will not yet reap it. WNOWAIT asks the question directly.
 func waitForTestChildExit(t *testing.T, pid int) {
 	t.Helper()
-	if err := waitForRuncStubProcessExit(pid, 30*time.Second); err != nil {
-		t.Fatalf("wait for child %d to exit: %v", pid, err)
+
+	deadline := time.Now().Add(30 * time.Second)
+	for {
+		var info unix.Siginfo
+		err := unix.Waitid(unix.P_PID, pid, &info, unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, nil)
+		if err != nil {
+			t.Fatalf("wait for child %d to exit: %v", pid, err)
+		}
+		// With WNOHANG a child that is not yet reapable leaves the siginfo
+		// zeroed rather than reporting an error.
+		if info.Signo != 0 {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for child %d to become reapable", pid)
+		}
+		time.Sleep(time.Millisecond)
 	}
 }

--- a/create_test.go
+++ b/create_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWorkloadState(t *testing.T) {
+	t.Run("a workload that exited before it could be reported reports its exit status", func(t *testing.T) {
+		pid := startTestChild(t, runcStubConfig{ExitCode: 19})
+		waitForTestChildExit(t, pid)
+
+		st, err := workloadState(pid)
+		if err != nil {
+			t.Fatalf("read workload state: %v", err)
+		}
+		if st.Pid != uint32(pid) || st.ExitCode != 19 || st.Status != "exited" {
+			t.Fatalf("state = %s, want pid %d, exit 19, status exited", st, pid)
+		}
+		if st.ExitedAt.IsZero() {
+			t.Fatal("exited state has no exit timestamp")
+		}
+	})
+
+	t.Run("a workload killed by a signal reports 128 plus the signal", func(t *testing.T) {
+		pid := startTestChild(t, runcStubConfig{ExitDelay: time.Hour})
+		if err := unix.Kill(pid, unix.SIGKILL); err != nil {
+			t.Fatalf("kill child %d: %v", pid, err)
+		}
+		waitForTestChildExit(t, pid)
+
+		st, err := workloadState(pid)
+		if err != nil {
+			t.Fatalf("read workload state: %v", err)
+		}
+		// containerd reports termination by signal as 128+signal, which is what
+		// its clients render as 137 for SIGKILL.
+		if want := uint32(exitSignalOffset + int(unix.SIGKILL)); st.ExitCode != want || st.Status != "exited" {
+			t.Fatalf("state = %s, want exit %d, status exited", st, want)
+		}
+	})
+
+	t.Run("a workload that is still running is left for systemd to reap", func(t *testing.T) {
+		pid := startTestChild(t, runcStubConfig{ExitDelay: time.Hour})
+
+		st, err := workloadState(pid)
+		if err != nil {
+			t.Fatalf("read workload state: %v", err)
+		}
+		if st.Pid != uint32(pid) || st.Status != "running" {
+			t.Fatalf("state = %s, want pid %d, status running", st, pid)
+		}
+
+		// systemd inherits the workload when the create re-exec exits and reports
+		// its exit status, so that status must still be there to collect.
+		if err := unix.Kill(pid, unix.SIGKILL); err != nil {
+			t.Fatalf("kill child %d: %v", pid, err)
+		}
+		waitForTestChildExit(t, pid)
+		var ws unix.WaitStatus
+		reaped, err := unix.Wait4(pid, &ws, unix.WNOHANG, nil)
+		if reaped != pid || err != nil {
+			t.Fatalf("wait4 for running workload %d = %d, %v; its status was consumed here instead of being left for systemd", pid, reaped, err)
+		}
+	})
+
+	t.Run("a pid this process never adopted is an error, not a zero exit", func(t *testing.T) {
+		// Pid 1 is never a child of the create re-exec, so its status cannot be
+		// read here. Reporting that as an exit of 0 is the failure to avoid.
+		st, err := workloadState(1)
+		if err == nil {
+			t.Fatalf("state of pid 1 = %s, want an error", st)
+		}
+	})
+}
+
+func TestReadPidFile(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("the pid runc recorded is the pid reported", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "pid")
+		if err := os.WriteFile(path, []byte("4321\n"), 0600); err != nil {
+			t.Fatalf("write pid file: %v", err)
+		}
+
+		pid, err := readPidFile(ctx, path)
+		if err != nil {
+			t.Fatalf("read pid file: %v", err)
+		}
+		if pid != 4321 {
+			t.Fatalf("pid = %d, want 4321", pid)
+		}
+	})
+
+	t.Run("a pid file runc never wrote is an error rather than a wait", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(ctx)
+		cancel()
+
+		if pid, err := readPidFile(ctx, filepath.Join(t.TempDir(), "pid")); err == nil {
+			t.Fatalf("read of a missing pid file returned pid %d, want an error", pid)
+		}
+	})
+}
+
+// startTestChild forks a child that runs to the given config and returns its
+// pid. os/exec is deliberately not used: these tests assert on what wait4
+// reports, so the child must have no waiter of its own.
+func startTestChild(t *testing.T, cfg runcStubConfig) int {
+	t.Helper()
+	cfg.StartImmediately = true
+
+	dir := t.TempDir()
+	if err := writeRuncStubConfig(dir, cfg); err != nil {
+		t.Fatalf("write child config: %v", err)
+	}
+	helper := filepath.Join(dir, managedProcessHelperName)
+	if err := os.Symlink(testExecutable(t), helper); err != nil {
+		t.Fatalf("create child helper: %v", err)
+	}
+
+	pid, err := syscall.ForkExec(helper, []string{managedProcessHelperName, dir}, &syscall.ProcAttr{
+		Env:   os.Environ(),
+		Files: []uintptr{0, 1, 2},
+	})
+	if err != nil {
+		t.Fatalf("fork child: %v", err)
+	}
+
+	// Every case here is an assertion about which children this process has, so
+	// no child may outlive the case that started it.
+	t.Cleanup(func() {
+		// Only signal a pid this process still owns: once the child has been
+		// reaped the number belongs to whatever process gets it next.
+		var ws unix.WaitStatus
+		if reaped, err := unix.Wait4(pid, &ws, unix.WNOHANG, nil); err != nil || reaped == pid {
+			return
+		}
+		unix.Kill(pid, unix.SIGKILL)
+		unix.Wait4(pid, nil, 0, nil)
+	})
+	return pid
+}
+
+func waitForTestChildExit(t *testing.T, pid int) {
+	t.Helper()
+	if err := waitForRuncStubProcessExit(pid, 30*time.Second); err != nil {
+		t.Fatalf("wait for child %d to exit: %v", pid, err)
+	}
+}

--- a/runc_stub_test.go
+++ b/runc_stub_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/containerd/containerd/v2/core/mount"
 	"github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -523,24 +524,30 @@ func waitForRuncStubFile(path string, timeout time.Duration) error {
 	return fmt.Errorf("timed out waiting for %s", path)
 }
 
+// waitForRuncStubProcessExit blocks until pid is reapable, without reaping it --
+// the exited workload is left for whoever is meant to collect its status.
+//
+// It asks waitid rather than polling /proc/<pid>/stat for state Z, because those
+// are different questions: the child is this binary re-executed and so is
+// multi-threaded, and its main thread is Z while the rest of the thread group is
+// still exiting, which is a window where wait4 will not yet reap it.
 func waitForRuncStubProcessExit(pid int, timeout time.Duration) error {
-	path := filepath.Join("/proc", strconv.Itoa(pid), "stat")
 	deadline := time.Now().Add(timeout)
-	for time.Now().Before(deadline) {
-		data, err := os.ReadFile(path)
-		if err != nil {
+	for {
+		var info unix.Siginfo
+		if err := unix.Waitid(unix.P_PID, pid, &info, unix.WEXITED|unix.WNOWAIT|unix.WNOHANG, nil); err != nil {
 			return err
 		}
-		endCommand := strings.LastIndexByte(string(data), ')')
-		if endCommand >= 0 {
-			fields := strings.Fields(string(data[endCommand+1:]))
-			if len(fields) > 0 && fields[0] == "Z" {
-				return nil
-			}
+		// With WNOHANG a child that is not yet reapable leaves the siginfo
+		// zeroed rather than reporting an error.
+		if info.Signo != 0 {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timed out waiting for process %d to exit", pid)
 		}
 		time.Sleep(time.Millisecond)
 	}
-	return fmt.Errorf("timed out waiting for process %d to exit", pid)
 }
 
 func setRuncStubExitCode(cfg *runcStubConfig, value string) error {

--- a/state.go
+++ b/state.go
@@ -89,19 +89,14 @@ func getUnitState(ctx context.Context, conn *dbus.Conn, unit string, st *pState)
 	if p := state["ExecMainPID"]; p != nil {
 		st.Pid = uint32(p.(uint32))
 	}
-	if c := state["ExecMainStatus"]; c != nil {
-		st.ExitCode = uint32(c.(int32))
-	}
 	// systemd reports a killed main process as the bare signal number, with
-	// ExecMainCode carrying the si_code that says so. containerd reports
-	// termination by signal as 128+signal, so translate here -- otherwise the
-	// same kill is reported as 9 or 137 depending only on whether this read or
-	// the create helper's own wait4 got there first.
-	if code := state["ExecMainCode"]; code != nil && st.ExitCode > 0 {
-		switch code.(int32) {
-		case cldKilled, cldDumped:
-			st.ExitCode += exitSignalOffset
+	// ExecMainCode carrying the si_code that says so.
+	if c := state["ExecMainStatus"]; c != nil {
+		var mainCode int32
+		if v := state["ExecMainCode"]; v != nil {
+			mainCode = v.(int32)
 		}
+		st.ExitCode = exitStatusFor(mainCode, c.(int32))
 	}
 
 	// if ts := state["ExecMainExitTimestamp"]; ts != nil {
@@ -312,11 +307,32 @@ const (
 	// e.g. 137 for SIGKILL.
 	exitSignalOffset = 128
 
-	// cldKilled and cldDumped are the si_code values systemd exposes as
-	// ExecMainCode when the main process was terminated by a signal.
+	// cldExited, cldKilled and cldDumped are the si_code values systemd exposes
+	// as ExecMainCode: whether the main process returned an exit code or was
+	// terminated by a signal.
+	cldExited = 1
 	cldKilled = 2
 	cldDumped = 3
 )
+
+// exitStatusFor turns a systemd (ExecMainCode, ExecMainStatus) pair into the
+// exit status containerd expects. systemd reports a process terminated by a
+// signal as the bare signal number, distinguished only by the si_code in
+// ExecMainCode; containerd reports it as 128+signal.
+//
+// Both places the shim learns an exit from systemd -- the reactor's signal
+// decoder and the GetAll fallback -- go through this, so the same kill cannot
+// come out as 9 or 137 depending on which of them saw it first.
+func exitStatusFor(mainCode, mainStatus int32) uint32 {
+	if mainStatus <= 0 {
+		return 0
+	}
+	switch mainCode {
+	case cldKilled, cldDumped:
+		return uint32(mainStatus) + exitSignalOffset
+	}
+	return uint32(mainStatus)
+}
 
 func toStatus(s string) task.Status {
 	switch s {

--- a/state.go
+++ b/state.go
@@ -92,6 +92,17 @@ func getUnitState(ctx context.Context, conn *dbus.Conn, unit string, st *pState)
 	if c := state["ExecMainStatus"]; c != nil {
 		st.ExitCode = uint32(c.(int32))
 	}
+	// systemd reports a killed main process as the bare signal number, with
+	// ExecMainCode carrying the si_code that says so. containerd reports
+	// termination by signal as 128+signal, so translate here -- otherwise the
+	// same kill is reported as 9 or 137 depending only on whether this read or
+	// the create helper's own wait4 got there first.
+	if code := state["ExecMainCode"]; code != nil && st.ExitCode > 0 {
+		switch code.(int32) {
+		case cldKilled, cldDumped:
+			st.ExitCode += exitSignalOffset
+		}
+	}
 
 	// if ts := state["ExecMainExitTimestamp"]; ts != nil {
 	// st.ExitedAt = time.UnixMicro(int64(ts.(uint64)))
@@ -295,6 +306,16 @@ func (p *execProcess) State(ctx context.Context) (*State, error) {
 
 const (
 	exitedInit = "exited-init"
+
+	// exitSignalOffset matches containerd's own reaper: a process terminated by
+	// a signal is reported as 128+signal, which is what its clients render as
+	// e.g. 137 for SIGKILL.
+	exitSignalOffset = 128
+
+	// cldKilled and cldDumped are the si_code values systemd exposes as
+	// ExecMainCode when the main process was terminated by a signal.
+	cldKilled = 2
+	cldDumped = 3
 )
 
 func toStatus(s string) task.Status {

--- a/unitevents_test.go
+++ b/unitevents_test.go
@@ -721,6 +721,7 @@ func serviceExitUpdate(unit string, pid, exitCode uint32, exitedAt time.Time) un
 		changed: map[string]dbus.Variant{
 			"ExecMainPID":           dbus.MakeVariant(pid),
 			"ExecMainStatus":        dbus.MakeVariant(int32(exitCode)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldExited)),
 			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(exitedAt.UnixMicro())),
 		},
 	}

--- a/unitsignals.go
+++ b/unitsignals.go
@@ -136,6 +136,19 @@ func serviceExitState(changed map[string]dbus.Variant) (pState, bool) {
 		return pState{}, false
 	}
 
+	// systemd emits ExecMainCode alongside ExecMainStatus, and it is what tells
+	// a signal number apart from an exit code. Without it the exit cannot be
+	// translated the way containerd expects, so leave the signal to the Unit
+	// ActiveState path, whose reconcile reads every property and gets it right.
+	codeValue, ok := changed["ExecMainCode"]
+	if !ok {
+		return pState{}, false
+	}
+	code, ok := codeValue.Value().(int32)
+	if !ok {
+		return pState{}, false
+	}
+
 	exitValue, ok := changed["ExecMainExitTimestamp"]
 	if !ok {
 		return pState{}, false
@@ -147,7 +160,7 @@ func serviceExitState(changed map[string]dbus.Variant) (pState, bool) {
 
 	return pState{
 		Pid:      pid,
-		ExitCode: uint32(status),
+		ExitCode: exitStatusFor(code, status),
 		ExitedAt: time.UnixMicro(int64(exitedAt)),
 		Status:   "exited",
 	}, true

--- a/unitsignals_test.go
+++ b/unitsignals_test.go
@@ -7,6 +7,7 @@ import (
 
 	systemd "github.com/coreos/go-systemd/v22/dbus"
 	"github.com/godbus/dbus/v5"
+	"golang.org/x/sys/unix"
 )
 
 func TestDecodeSystemdPropertiesChanged(t *testing.T) {
@@ -82,6 +83,7 @@ func TestServiceExitState(t *testing.T) {
 		changed := map[string]dbus.Variant{
 			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
 			"ExecMainStatus":        dbus.MakeVariant(int32(17)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldExited)),
 			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(exitedAt.UnixMicro())),
 		}
 
@@ -94,10 +96,45 @@ func TestServiceExitState(t *testing.T) {
 		}
 	})
 
+	// The reactor is the shim's primary source of exits, so it has to translate
+	// a signal the same way a property read does -- otherwise the same kill is
+	// reported as 9 or 137 depending only on which of them saw it first.
+	t.Run("a signaled service reports 128 plus the signal", func(t *testing.T) {
+		exitedAt := time.Date(2026, time.July, 16, 12, 0, 0, 123000000, time.Local)
+		changed := map[string]dbus.Variant{
+			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
+			"ExecMainStatus":        dbus.MakeVariant(int32(unix.SIGKILL)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldKilled)),
+			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(exitedAt.UnixMicro())),
+		}
+
+		state, ok := serviceExitState(changed)
+		if !ok {
+			t.Fatal("terminal service properties were not recognized")
+		}
+		if want := uint32(exitSignalOffset + int(unix.SIGKILL)); state.ExitCode != want {
+			t.Fatalf("state = %s, want exit %d", state, want)
+		}
+	})
+
+	t.Run("service properties without the exit code's si_code are left to the property read", func(t *testing.T) {
+		exitedAt := time.Date(2026, time.July, 16, 12, 0, 0, 123000000, time.Local)
+		changed := map[string]dbus.Variant{
+			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
+			"ExecMainStatus":        dbus.MakeVariant(int32(17)),
+			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(exitedAt.UnixMicro())),
+		}
+
+		if _, ok := serviceExitState(changed); ok {
+			t.Fatal("an exit was recorded without the si_code needed to translate it")
+		}
+	})
+
 	t.Run("service properties without an exit timestamp are not terminal", func(t *testing.T) {
 		changed := map[string]dbus.Variant{
 			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
 			"ExecMainStatus":        dbus.MakeVariant(int32(0)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldExited)),
 			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(0)),
 		}
 
@@ -110,6 +147,7 @@ func TestServiceExitState(t *testing.T) {
 		changed := map[string]dbus.Variant{
 			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
 			"ExecMainStatus":        dbus.MakeVariant(int32(-1)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldExited)),
 			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(time.Now().UnixMicro())),
 		}
 
@@ -210,6 +248,7 @@ func TestSignalIntakeDoesNotAllocate(t *testing.T) {
 		serviceSignal(systemd.PathBusEscape(ours), map[string]dbus.Variant{
 			"ExecMainPID":           dbus.MakeVariant(uint32(42)),
 			"ExecMainStatus":        dbus.MakeVariant(int32(3)),
+			"ExecMainCode":          dbus.MakeVariant(int32(cldExited)),
 			"ExecMainExitTimestamp": dbus.MakeVariant(uint64(time.Now().UnixMicro())),
 		}),
 		unitSignal(systemd.PathBusEscape(ours), failed),


### PR DESCRIPTION
`TestServiceExecIDReuseAgainstSystemd` fails intermittently in CI with
`wait exit status = 0, want 19` — the shim reports a clean exit for an exec that
exited non-zero.

## The race

The `create` re-exec raced itself over who reaped the workload. One goroutine
watched for `SIGCHLD` and reaped any child; the main path polled for runc's pid
file and then ran its own `wait4`. Between the goroutine's `wait4` and its send
on the channel, the zombie was gone but the status had not arrived yet. The main
path's `wait4` then found nothing — and because it discarded the error, could not
tell `ECHILD` (already reaped) from "still running":

```go
p, _ := unix.Wait4(pid, &status, unix.WNOHANG, nil)   // error discarded
if p == pid { ...exited... } else { st.Status = "running" }
```

Captured at the moment of failure, `exit_status.json` held:

```json
{"ExitedAt":"0001-01-01T00:00:00Z","ExitCode":0,"Pid":1290336,"Status":"running"}
```

That file is the only source of an exec's exit status — the unit's
`ExecMainStatus` is the *helper's* code, not the workload's — so the exit reached
containerd as a clean 0.

## The fix

The reaper goroutine and the pid-file poller are gone. runc writes the pid before
it exits, so it is read once, and `workloadState` makes the single `wait4` this
process performs. `ECHILD` is an error rather than an answer: the workload is not
ours to report, and "exited 0" is the failure worth avoiding. A workload that is
still running is deliberately left unwaited — systemd inherits it and reports its
exit, and a second wait here would consume the status systemd needs.

`sd_notify` is a datagram with no reply, so handing the main pid over does not
mean systemd has taken it. `sdNotifyBarrier` implements `BARRIER=1` and the code
then looks once more: systemd refuses a main pid that has already become a
zombie, so a workload that died mid-handoff is still ours to report. A barrier
that fails still re-checks — skipping it would restore the gap this closes.

Termination by signal is now reported as 128+signal, matching containerd's
reaper (`pkg/sys/reaper/reaper_unix.go`). This is done in both sources: the
`wait4` path, and `getUnitState`, which needs `ExecMainCode` to tell a signal
number from an exit code. Verified against systemd 260 — `kill -9` gives
`ExecMainCode=2, ExecMainStatus=9`; `exit 7` gives `ExecMainCode=1,
ExecMainStatus=7`. Changing only one source would have made the same kill report
9 or 137 depending on which got there first.

## Testing

- `go test -race ./...` including the live systemd integration tests.
- The race reproduces under `go test -race -count=40 -run TestServiceExecIDReuseAgainstSystemd`
  at roughly 0.75% (3 in ~400) before this change. Re-run against the fix, it is
  clean. Note that `-count=1` in separate processes never reproduced it in 50
  attempts, so single-run sweeps are not evidence of absence.
- `create_test.go` covers the two pure helpers. `TestWorkloadState` includes the
  regression directly: *"a pid this process never adopted is an error, not a zero
  exit"*, and a case asserting a still-running workload's status is left intact
  for systemd rather than consumed here.

## Follow-up, not in this PR

`exit_status.json` should stop being the source of truth at all, in favour of
systemd's own properties. That needs the helper to stop reaping entirely —
peeking with `waitid(..., WNOWAIT)` and then exiting as the workload did, so
systemd records the status itself. `EXIT_STATUS=` in `sd_notify` cannot be used
for this: it is documented as not consumed when sent by a service. Waiting on a
pidfd from runc's `--pidfd-socket` (runc 1.2.0+) would also remove pid reuse from
the picture, though `go-runc` does not expose that option yet.
