### PR TITLE
Replace the exit-status file with sd_notify

### DIFF
--- a/contrib/bench/html.go
+++ b/contrib/bench/html.go
@@ -118,7 +118,7 @@ func writeCharts(b *strings.Builder, r *Report) {
 
 	// Shim-internal fallback (systemd only).
 	section("Exit-state source: reactor vs GetAll (systemd shim)",
-		"Exit-state loads served by the in-memory D-Bus reactor vs the systemd GetAll fallback (hit rate = reactor ÷ (reactor+GetAll)). On-disk reads are a separate LoadState path, shown for volume — not part of the hit rate.",
+		"Exit-state loads served by the in-memory D-Bus reactor vs the systemd GetAll fallback (hit rate = reactor ÷ (reactor+GetAll)).",
 		chartFallback(r))
 
 	b.WriteString(`</section>`)
@@ -293,7 +293,7 @@ func chartAttribCPU(r *Report, scenario string) string {
 func chartFallback(r *Report) string {
 	// aggregate systemd shim counters per scenario name
 	order := []string{"container", "exec", "exec-tty", "container-tty", "status", "scale"}
-	type agg struct{ reactor, getall, ondisk int64 }
+	type agg struct{ reactor, getall int64 }
 	sums := map[string]*agg{}
 	for i := range r.Scenarios {
 		s := &r.Scenarios[i]
@@ -307,7 +307,6 @@ func chartFallback(r *Report) string {
 		}
 		a.reactor += s.ShimVars.ReactorHits
 		a.getall += s.ShimVars.GetAllFallbacks
-		a.ondisk += s.ShimVars.OnDiskReads
 	}
 	var cats []string
 	for _, name := range order {
@@ -320,17 +319,14 @@ func chartFallback(r *Report) string {
 	}
 	reactor := make([]float64, len(cats))
 	getall := make([]float64, len(cats))
-	ondisk := make([]float64, len(cats))
 	for i, name := range cats {
 		a := sums[name]
 		reactor[i] = float64(a.reactor)
 		getall[i] = float64(a.getall)
-		ondisk[i] = float64(a.ondisk)
 	}
 	segs := []stackSeg{
 		{"reactor hit", "var(--cat-1)", reactor},
 		{"GetAll fallback", "var(--cat-6)", getall},
-		{"on-disk read", "var(--cat-4)", ondisk},
 	}
 	return stackedBars("state-source", "events", cats, segs)
 }

--- a/contrib/bench/report.go
+++ b/contrib/bench/report.go
@@ -76,7 +76,7 @@ func writeResourceCSV(path string, r *Report) error {
 	for _, c := range sampledCategories {
 		header = append(header, "peak_pss_"+string(c))
 	}
-	header = append(header, "reactor_hits", "getall_fallbacks", "ondisk_reads", "reactor_hit_rate",
+	header = append(header, "reactor_hits", "getall_fallbacks", "reactor_hit_rate",
 		"shim_go_heap_bytes")
 	w.Write(header)
 
@@ -96,10 +96,9 @@ func writeResourceCSV(path string, r *Report) error {
 		if s.ShimVars != nil {
 			row = append(row, strconv.FormatInt(s.ShimVars.ReactorHits, 10),
 				strconv.FormatInt(s.ShimVars.GetAllFallbacks, 10),
-				strconv.FormatInt(s.ShimVars.OnDiskReads, 10),
 				f2(s.ShimVars.ReactorHitRate))
 		} else {
-			row = append(row, "", "", "", "")
+			row = append(row, "", "", "")
 		}
 		row = append(row, strconv.FormatUint(s.ShimGoHeapBytes, 10))
 		w.Write(row)

--- a/contrib/bench/report_test.go
+++ b/contrib/bench/report_test.go
@@ -119,8 +119,8 @@ func syntheticReport() Report {
 	mem := func(shim uint64) map[string]uint64 {
 		return map[string]uint64{"shim-systemd": shim, "tty-helper": 0, "shim-runc": shim, "runc": 4 << 20, "systemd": 20 << 20, "containerd": 30 << 20}
 	}
-	vars := func(hit, getall, ondisk int64) *ShimVarsDelta {
-		d := &ShimVarsDelta{ReactorHits: hit, GetAllFallbacks: getall, OnDiskReads: ondisk}
+	vars := func(hit, getall int64) *ShimVarsDelta {
+		d := &ShimVarsDelta{ReactorHits: hit, GetAllFallbacks: getall}
 		if hit+getall > 0 {
 			d.ReactorHitRate = float64(hit) / float64(hit+getall)
 		}
@@ -142,7 +142,7 @@ func syntheticReport() Report {
 				AttribCPUSeconds: 6.5 - float64(ri)*3, SystemUtilPct: 40 - float64(ri)*10,
 			}
 			if sysd {
-				c.ShimVars = vars(int64(90+p), int64(10), int64(2))
+				c.ShimVars = vars(int64(90+p), int64(10))
 				c.ShimGoHeapBytes = 12 << 20
 			}
 			add(c)
@@ -154,7 +154,7 @@ func syntheticReport() Report {
 				CPUSeconds: cpu(0.8, 1.1), MemPeakPss: mem(uint64(38+ri*8) << 20),
 			}
 			if sysd {
-				e.ShimVars = vars(int64(80), int64(5), int64(1))
+				e.ShimVars = vars(int64(80), int64(5))
 			}
 			add(e)
 
@@ -192,7 +192,7 @@ func syntheticReport() Report {
 				MemPeakPss: mem(uint64((30+ri*5)+n*(2+ri*3)) << 20),
 			}
 			if sysd {
-				sc.ShimVars = vars(int64(n*2), int64(1), 0)
+				sc.ShimVars = vars(int64(n*2), int64(1))
 			}
 			add(sc)
 		}

--- a/contrib/bench/scrape.go
+++ b/contrib/bench/scrape.go
@@ -14,7 +14,6 @@ import (
 type ShimVarsSnapshot struct {
 	ReactorHits     int64
 	GetAllFallbacks int64
-	OnDiskReads     int64
 	GetUnitCalls    int64
 	GoHeapAlloc     uint64
 }
@@ -23,7 +22,6 @@ type ShimVarsSnapshot struct {
 type ShimVarsDelta struct {
 	ReactorHits     int64   `json:"reactor_hits"`
 	GetAllFallbacks int64   `json:"getall_fallbacks"`
-	OnDiskReads     int64   `json:"ondisk_reads"`
 	GetUnitCalls    int64   `json:"getunitstate_calls"`
 	ReactorHitRate  float64 `json:"reactor_hit_rate"`
 }
@@ -55,7 +53,6 @@ func scrapeShimVars(ctx context.Context, url string) (*ShimVarsSnapshot, error) 
 		ShimState struct {
 			ReactorHits int64 `json:"exitstate_reactor_hits"`
 			GetAll      int64 `json:"exitstate_getall_fallbacks"`
-			OnDisk      int64 `json:"state_ondisk_reads"`
 			GetUnit     int64 `json:"getunitstate_calls"`
 		} `json:"shim_state"`
 		Memstats struct {
@@ -68,7 +65,6 @@ func scrapeShimVars(ctx context.Context, url string) (*ShimVarsSnapshot, error) 
 	return &ShimVarsSnapshot{
 		ReactorHits:     raw.ShimState.ReactorHits,
 		GetAllFallbacks: raw.ShimState.GetAll,
-		OnDiskReads:     raw.ShimState.OnDisk,
 		GetUnitCalls:    raw.ShimState.GetUnit,
 		GoHeapAlloc:     raw.Memstats.Alloc,
 	}, nil
@@ -82,7 +78,6 @@ func diffShimVars(before, after *ShimVarsSnapshot) *ShimVarsDelta {
 	d := &ShimVarsDelta{
 		ReactorHits:     after.ReactorHits - before.ReactorHits,
 		GetAllFallbacks: after.GetAllFallbacks - before.GetAllFallbacks,
-		OnDiskReads:     after.OnDiskReads - before.OnDiskReads,
 		GetUnitCalls:    after.GetUnitCalls - before.GetUnitCalls,
 	}
 	if total := d.ReactorHits + d.GetAllFallbacks; total > 0 {

--- a/create.go
+++ b/create.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -86,7 +85,6 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 		switch vv := v.(type) {
 		case *options.CreateOptions:
 			opts.LogMode = vv.LogMode.String()
-			opts.SdNotifyEnable = vv.SdNotifyEnable
 			// TODO: Add other runc options to our CreateOptions.
 		case *v2runcopts.Options:
 			opts.NoPivotRoot = vv.NoPivotRoot
@@ -124,7 +122,7 @@ func (s *Service) Create(ctx context.Context, r *taskapi.CreateTaskRequest) (_ *
 		logPath = filepath.Join(r.Bundle, "init-runc-debug.log")
 	}
 
-	specData, err := ioutil.ReadFile(filepath.Join(r.Bundle, "config.json"))
+	specData, err := os.ReadFile(filepath.Join(r.Bundle, "config.json"))
 	if err != nil {
 		return nil, fmt.Errorf("error reading spec: %w", err)
 	}
@@ -526,48 +524,61 @@ func (p *initProcess) startUnit(ctx context.Context) (uint32, error) {
 			if status != "done" {
 				return fmt.Errorf("error starting systemd unit: %s", status)
 			}
-
-			if err := p.LoadState(ctx); err != nil {
-				return err
-			}
-
-			if p.ProcessState().Exited() {
-				return fmt.Errorf("container exited immediately, code: %d", p.ProcessState().ExitCode)
-			}
+			// No exit check here. The unit is Type=notify, so "done" means the
+			// create re-exec sent READY=1, which it only does for a workload that
+			// was running when it looked. A workload that died before that never
+			// reaches "done". One that dies during the MAINPID handoff still can,
+			// and handlePid below makes exactly this check against state the
+			// reactor has by then applied -- reading it here only asks systemd for
+			// an answer the next call already produces.
 		}
 
 		return nil
 	}
 
+	// handlePid resolves the pid runc left behind, and reports an exit that
+	// happened before this ran.
+	//
+	// The pid comes off disk rather than out of systemd. runc wrote it before it
+	// exited, and the unit reaching "done" means the create re-exec had already
+	// read that same file and handed the value over as MAINPID=, so ExecMainPID
+	// is a D-Bus round trip for a number already sitting in the bundle.
+	//
+	// The systemd fallback is for the caller below that runs this after do()
+	// failed: the unit may never have started, or may still be coming up.
 	handlePid := func() (uint32, error) {
-		if err := p.LoadState(ctx); err != nil {
-			log.G(ctx).WithError(err).Error("Error loading state")
-		}
-		for retries := 0; retries < 10 && p.Pid() == 0 && !p.ProcessState().Exited(); retries++ {
-			select {
-			case <-ctx.Done():
-				return 0, ctx.Err()
-			default:
-			}
+		pid, err := parsePidFile(p.pidFile())
+		if err != nil {
+			log.G(ctx).WithError(err).Debug("No usable runc pid file; reading state from systemd")
 
-			time.Sleep(10 * time.Millisecond)
 			if err := p.LoadState(ctx); err != nil {
 				log.G(ctx).WithError(err).Error("Error loading state")
 			}
-		}
-		pid := p.Pid()
+			for retries := 0; retries < 10 && p.Pid() == 0 && !p.ProcessState().Exited(); retries++ {
+				select {
+				case <-ctx.Done():
+					return 0, ctx.Err()
+				default:
+				}
 
-		p.mu.Lock()
-		if p.state.Pid == 0 {
-			p.state.Pid = uint32(pid)
+				time.Sleep(10 * time.Millisecond)
+				if err := p.LoadState(ctx); err != nil {
+					log.G(ctx).WithError(err).Error("Error loading state")
+				}
+			}
+			pid = p.Pid()
+		} else {
+			// Record it the way the systemd read used to: applyState rewrites
+			// "running" to "created" while the phase is below running, so this
+			// lands the same state without the round trip.
+			p.SetState(ctx, pState{Pid: pid, Status: "running"})
 		}
-		p.mu.Unlock()
-		var err error
+
 		if p.ProcessState().Exited() {
 			p.cond.Broadcast()
-			err = fmt.Errorf("container exited immediately, code: %d", p.ProcessState().ExitCode)
+			return pid, fmt.Errorf("container exited immediately, code: %d", p.ProcessState().ExitCode)
 		}
-		return uint32(pid), err
+		return pid, nil
 	}
 
 	if err := do(); err != nil {
@@ -724,27 +735,14 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 		retErr = fmt.Errorf("process exited with code %d", st.ExitCode)
 	}()
 
-	writeFile := func() error {
-		data, err := json.Marshal(st)
-		if err != nil {
-			return fmt.Errorf("error marshalling state: %v", err)
-		}
-
-		if err := os.WriteFile(os.Getenv("EXIT_STATE_PATH"), data, 0600); err != nil {
-			return fmt.Errorf("error writing state: %v", err)
-		}
-		return nil
-	}
-
 	if err := cmd.Wait(); err != nil {
-		// runc exited non-zero
+		// runc exited non-zero. It never produced a workload, so there is no pid
+		// to report: the pid runc ran under must not be mistaken for one.
 		st.ExitCode = uint32(cmd.ProcessState.ExitCode())
 		st.ExitedAt = time.Now()
 		st.Status = exitedInit
-		st.Pid = uint32(cmd.Process.Pid)
-		err = writeFile()
-		sdNotify(ctx, notifyErrno(st.ExitCode), notifyStatus(st.Status))
-		return err
+		notifyWorkload(ctx, st)
+		return nil
 	}
 
 	// runc detaches, so it has written the pid of the process it left behind
@@ -754,16 +752,20 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 		return err
 	}
 
-	st = pState{Pid: uint32(pid)}
-	if !noReap {
-		if st, err = workloadState(pid); err != nil {
-			return err
-		}
+	st = pState{Pid: uint32(pid), Status: "running"}
+	if noReap {
+		// Nothing here set PR_SET_CHILD_SUBREAPER, so the workload reparents to
+		// systemd, which reaps it and records its exit. Announcing the pid is the
+		// whole job: this process has no exit to report and nothing to re-check.
+		// The unit is Type=notify, so skipping the announcement would fail it.
+		notifyWorkload(ctx, st)
+		return nil
 	}
 
-	if err := writeFile(); err != nil {
+	if st, err = workloadState(pid); err != nil {
 		return err
 	}
+
 	notifyWorkload(ctx, st)
 
 	if st.Status != "running" {
@@ -789,9 +791,6 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 		// systemd has the pid and the pid is alive, so systemd owns its exit.
 		return nil
 	}
-	if err := writeFile(); err != nil {
-		return err
-	}
 	notifyWorkload(ctx, st)
 	return nil
 }
@@ -800,17 +799,32 @@ func createCmd(ctx context.Context, bundle string, cmdLine []string, tty, noReap
 // exits, so this only covers a write that has not landed yet.
 const pidFileTimeout = 5 * time.Second
 
-// readPidFile reads the pid runc recorded for the process it left behind.
+// parsePidFile reads the pid runc recorded at path. runc writes the file before
+// it exits, so any caller that has seen runc finish will find it complete.
+func parsePidFile(path string) (uint32, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, err
+	}
+	pid, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid pid in %s: %w", path, err)
+	}
+	if pid == 0 {
+		return 0, fmt.Errorf("pid file %s contains zero", path)
+	}
+	return uint32(pid), nil
+}
+
+// readPidFile waits for runc to record the pid of the process it left behind.
+// runc writes it before it exits, so this only covers a write that has not
+// landed yet.
 func readPidFile(ctx context.Context, path string) (int, error) {
 	deadline := time.Now().Add(pidFileTimeout)
 	for {
-		data, err := os.ReadFile(path)
+		pid, err := parsePidFile(path)
 		if err == nil {
-			var pid int
-			if pid, err = strconv.Atoi(strings.TrimSpace(string(data))); err == nil {
-				return pid, nil
-			}
-			err = fmt.Errorf("invalid pid in %s: %w", path, err)
+			return int(pid), nil
 		}
 
 		if time.Now().After(deadline) {
@@ -864,13 +878,19 @@ func workloadState(pid int) (pState, error) {
 	return st, nil
 }
 
+// notifyWorkload tells systemd what runc left behind. It is the only channel
+// the shim has for a workload systemd never got to reap for itself, so a state
+// it cannot describe must not be reported at all rather than reported wrongly.
 func notifyWorkload(ctx context.Context, st pState) {
 	switch st.Status {
-	case "exited":
-		sdNotify(ctx, notifyStatus(st.Status), notifyErrno(st.ExitCode), notifyMainPID(st.Pid))
 	case "running":
 		sdNotify(ctx, daemon.SdNotifyReady, notifyMainPID(st.Pid))
 		log.G(ctx).Debug("Process is up!")
+	case exitedInit, "exited":
+		// No MAINPID: systemd refuses a pid that has already exited, and for an
+		// exited-init there is no workload pid in the first place. The pid the
+		// shim needs travels in the status text instead.
+		sdNotify(ctx, notifyStatus(st), notifyErrno(st.ExitCode))
 	}
 }
 
@@ -889,8 +909,18 @@ func notifyMainPID(pid uint32) string {
 	return fmt.Sprintf("MAINPID=%d", pid)
 }
 
-func notifyStatus(status string) string {
-	return fmt.Sprintf("STATUS=%s", status)
+// notifyStatus renders the STATUS= line: the systemd-shaped status, and the
+// workload's pid when there is one.
+//
+// STATUS= is the only free-form text systemd retains for a unit, which makes it
+// the one place a pid can survive an exit systemd did not witness -- MAINPID= is
+// refused for a process that is already dead, so ExecMainPID names this process
+// rather than the workload. parseStatusText reads it back.
+func notifyStatus(st pState) string {
+	if st.Pid == 0 {
+		return "STATUS=" + st.Status
+	}
+	return fmt.Sprintf("STATUS=%s %d", st.Status, st.Pid)
 }
 
 func notifyErrno(errno uint32) string {

--- a/delete.go
+++ b/delete.go
@@ -176,6 +176,10 @@ func (p *initProcess) Delete(ctx context.Context) (retState pState, retErr error
 		if err != nil {
 			return pState{}, err
 		}
+	} else {
+		// A process whose runc invocation failed never had a workload pid to
+		// wait on, but the failure is its exit and containerd still asks for it.
+		ps = p.ProcessState()
 	}
 
 	if p.Terminal {
@@ -255,6 +259,10 @@ func (p *execProcess) Delete(ctx context.Context) (retState pState, retErr error
 		if err != nil {
 			return pState{}, err
 		}
+	} else {
+		// A process whose runc invocation failed never had a workload pid to
+		// wait on, but the failure is its exit and containerd still asks for it.
+		ps = p.ProcessState()
 	}
 	p.finishDelete(ctx)
 

--- a/integration_test.go
+++ b/integration_test.go
@@ -46,7 +46,15 @@ func TestReactorReactsToRealExit(t *testing.T) {
 
 		startTransient(t, ctx, conn, unit, []string{"/bin/sh", "-c", "exit 3"})
 
-		if !eventually(10*time.Second, 10*time.Millisecond, func() bool { return p.LoadStateCalls() >= 1 }) {
+		// A reconcile answers from the reactor's own recording when the signal
+		// carried the exit, and reads systemd when it did not. Either is the
+		// reactor handling the exit, so count both -- asserting on the read alone
+		// would make this test a check on which path happened to win.
+		reactions := func() int64 {
+			return int64(p.LoadStateCalls() + p.LoadRecordedExitStateCalls())
+		}
+
+		if !eventually(10*time.Second, 10*time.Millisecond, func() bool { return reactions() >= 1 }) {
 			t.Fatal("reactor never observed the unit exit")
 		}
 
@@ -54,7 +62,7 @@ func TestReactorReactsToRealExit(t *testing.T) {
 		// stableFor returns as soon as the count stops changing, so a correct
 		// (single-reaction) run returns after the short debounce rather than a
 		// fixed delay; a duplicate-reaction bug keeps it climbing until timeout.
-		if got := stableFor(10*time.Second, 300*time.Millisecond, 10*time.Millisecond, func() int64 { return int64(p.LoadStateCalls()) }); got != 1 {
+		if got := stableFor(10*time.Second, 300*time.Millisecond, 10*time.Millisecond, reactions); got != 1 {
 			t.Fatalf("expected exactly one reaction to a single exit, got %d", got)
 		}
 	})

--- a/manager.go
+++ b/manager.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"sync/atomic"
 	"time"
 
 	"github.com/containerd/cgroups/v3"
@@ -166,6 +167,15 @@ type Service struct {
 
 	processes *processManager
 	units     *unitManager
+
+	// reactorUp reports whether the signal stream is currently connected. While
+	// it is, no unit event can have been missed -- the D-Bus client hands
+	// overflowed signals to goroutines rather than dropping them -- so the shim's
+	// in-memory state is current and a caller need not read systemd to check it.
+	// A drop is recovered by the resync on reconnect, which reconciles every
+	// tracked unit, so this only has to be conservative while the stream is
+	// actually down.
+	reactorUp atomic.Bool
 
 	defaultLogMode options.LogMode
 

--- a/metrics.go
+++ b/metrics.go
@@ -4,15 +4,13 @@ import (
 	"expvar"
 )
 
-// State-source metric keys. These count how the shim answers process
-// state/exit queries: from the in-memory D-Bus event reactor (the fast path)
-// versus falling back to a systemd GetAll property read or an on-disk exit
-// file. The reactor-hit vs getall-fallback ratio is the event reactor's
-// effective hit rate; on-disk reads are the other fallback source.
+// State-source metric keys. These count how the shim resolves a process's exit:
+// from the in-memory D-Bus event reactor (the fast path) versus having to read
+// the unit's properties from systemd. The reactor-hit vs getall-fallback ratio
+// is the event reactor's effective hit rate.
 const (
 	metricReactorHits     = "exitstate_reactor_hits"
 	metricGetAllFallbacks = "exitstate_getall_fallbacks"
-	metricOnDiskReads     = "state_ondisk_reads"
 	metricGetUnitCalls    = "getunitstate_calls"
 )
 
@@ -25,7 +23,6 @@ var stateMetrics = func() *expvar.Map {
 	for _, k := range []string{
 		metricReactorHits,
 		metricGetAllFallbacks,
-		metricOnDiskReads,
 		metricGetUnitCalls,
 	} {
 		m.Add(k, 0)

--- a/options/options.pb.go
+++ b/options/options.pb.go
@@ -74,11 +74,10 @@ func (LogMode) EnumDescriptor() ([]byte, []int) {
 }
 
 type CreateOptions struct {
-	state          protoimpl.MessageState `protogen:"open.v1"`
-	LogMode        LogMode                `protobuf:"varint,1,opt,name=log_mode,json=logMode,proto3,enum=containerd.systemd.v1.LogMode" json:"log_mode,omitempty"`
-	SdNotifyEnable bool                   `protobuf:"varint,2,opt,name=sd_notify_enable,json=sdNotifyEnable,proto3" json:"sd_notify_enable,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	LogMode       LogMode                `protobuf:"varint,1,opt,name=log_mode,json=logMode,proto3,enum=containerd.systemd.v1.LogMode" json:"log_mode,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *CreateOptions) Reset() {
@@ -118,21 +117,13 @@ func (x *CreateOptions) GetLogMode() LogMode {
 	return LogMode_DEFAULT
 }
 
-func (x *CreateOptions) GetSdNotifyEnable() bool {
-	if x != nil {
-		return x.SdNotifyEnable
-	}
-	return false
-}
-
 var File_options_options_proto protoreflect.FileDescriptor
 
 const file_options_options_proto_rawDesc = "" +
 	"\n" +
-	"\x15options/options.proto\x12\x15containerd.systemd.v1\"t\n" +
+	"\x15options/options.proto\x12\x15containerd.systemd.v1\"b\n" +
 	"\rCreateOptions\x129\n" +
-	"\blog_mode\x18\x01 \x01(\x0e2\x1e.containerd.systemd.v1.LogModeR\alogMode\x12(\n" +
-	"\x10sd_notify_enable\x18\x02 \x01(\bR\x0esdNotifyEnable*9\n" +
+	"\blog_mode\x18\x01 \x01(\x0e2\x1e.containerd.systemd.v1.LogModeR\alogModeJ\x04\b\x02\x10\x03R\x10sd_notify_enable*9\n" +
 	"\aLogMode\x12\v\n" +
 	"\aDEFAULT\x10\x00\x12\f\n" +
 	"\bJOURNALD\x10\x01\x12\t\n" +

--- a/options/options.proto
+++ b/options/options.proto
@@ -13,5 +13,10 @@ enum LogMode {
 
 message CreateOptions {
     LogMode log_mode = 1;
-    bool sd_notify_enable = 2;
+
+    // sd_notify_enable only ever toggled the unit type. Every unit is
+    // Type=notify now, and the option never gave the workload the notify
+    // socket it implied.
+    reserved 2;
+    reserved "sd_notify_enable";
 }

--- a/process.go
+++ b/process.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -127,10 +126,14 @@ type Process interface {
 	// identifier the event reactor matches incoming signals against.
 	PathName() string
 	LoadState(context.Context) error
-	// LoadExitState refreshes the process from terminal systemd properties
-	// recorded by the signal stream, falling back to GetAll when necessary.
-	LoadExitState(context.Context) error
+	// LoadRecordedExitState applies the terminal state the reactor decoded from
+	// the unit's signal, and reports whether there was one. It does no I/O, so
+	// it is what a reconcile asks before it considers reading systemd.
+	LoadRecordedExitState(context.Context) bool
 	RecordSystemdExitState(pState)
+	// RecordHelperExitState records the create re-exec's own report of an exit,
+	// which outranks anything systemd publishes for the unit afterwards.
+	RecordHelperExitState(pState)
 	SetState(context.Context, pState) pState
 	ProcessState() pState
 	LogWriter() io.Writer
@@ -138,8 +141,7 @@ type Process interface {
 
 type CreateOptions struct {
 	// Native config
-	LogMode        string
-	SdNotifyEnable bool
+	LogMode string
 
 	// From runc types
 	BinaryName          string
@@ -237,6 +239,10 @@ type process struct {
 
 	systemdExitState    pState
 	hasSystemdExitState bool
+	// helperExitState records that systemdExitState came from the create
+	// re-exec rather than from systemd's own account of the unit, which makes
+	// it the last word on the workload's exit.
+	helperExitState bool
 
 	shimCgroup string
 }
@@ -303,12 +309,32 @@ func (p *process) abortStart(ctx context.Context) {
 	}
 }
 
+// RecordSystemdExitState records terminal properties systemd published for the
+// unit. A later update refines an earlier one.
+//
+// Nothing systemd publishes can replace the create re-exec's own report. Once
+// the re-exec has reported an exit systemd never witnessed, the re-exec is
+// still the unit's main process, so the ExecMain properties systemd goes on to
+// publish describe the re-exec's exit rather than the workload's.
 func (p *process) RecordSystemdExitState(state pState) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.helperExitState {
+		return
+	}
 	if !p.hasSystemdExitState || state.ExitedAt.After(p.systemdExitState.ExitedAt) {
 		p.systemdExitState = state
 		p.hasSystemdExitState = true
 	}
+}
+
+// RecordHelperExitState records the create re-exec's report of an exit systemd
+// never witnessed, which is the only account of that exit there is.
+func (p *process) RecordHelperExitState(state pState) {
+	p.mu.Lock()
+	p.systemdExitState = state
+	p.hasSystemdExitState = true
+	p.helperExitState = true
 	p.mu.Unlock()
 }
 
@@ -316,6 +342,7 @@ func (p *process) clearRecordedSystemdExitState() {
 	p.mu.Lock()
 	p.systemdExitState.Reset()
 	p.hasSystemdExitState = false
+	p.helperExitState = false
 	p.mu.Unlock()
 }
 
@@ -553,21 +580,29 @@ func (p *initProcess) SetState(ctx context.Context, state pState) pState {
 	u := p.applyState(ctx, state)
 	st := u.state
 	if u.justExited() {
-		if st.Status != exitedInit && u.wasRunning() && p.killAllOnExit {
+		if u.wasRunning() && p.killAllOnExit {
 			if err := p.runc.Kill(ctx, p.id, int(syscall.SIGKILL), &runc.KillOpts{All: true}); err != nil {
 				log.G(ctx).WithError(err).WithField("id", p.id).Error("failed to kill init's children")
 			}
 		}
 		log.G(ctx).Debugf("EXITED: %s %s", p.Name(), st)
 		p.execs.Each(func(exec Process) {
-			if err := exec.LoadState(ctx); err != nil {
-				log.G(ctx).WithError(err).WithField("exec", p.Name()).Info("Could not load exec state")
-			}
-			// An exec that never started has no process to reap. Leave it in its
-			// Created state so callers see it never ran, rather than synthesizing
-			// a non-zero exit for a process that was only ever set up.
-			if ep, ok := exec.(*execProcess); ok && ep.currentPhase() < phaseRunning {
-				return
+			if ep, ok := exec.(*execProcess); ok {
+				// An exec that never started has no process to reap. Leave it in
+				// its Created state so callers see it never ran, rather than
+				// synthesizing a non-zero exit for a process that was only ever
+				// set up.
+				if ep.currentPhase() < phaseRunning {
+					return
+				}
+				// The container's exit takes every exec with it, but an exec that
+				// exited on its own has a real exit code worth keeping. Take one
+				// the reactor has already recorded; do not read systemd per exec
+				// here, because those units are dying too and each has its own
+				// reconcile queued to do exactly that.
+				if st, ok := ep.loadRecordedSystemdExitState(); ok {
+					ep.SetState(ctx, st)
+				}
 			}
 			if !exec.ProcessState().Exited() {
 				exec.SetState(ctx, pState{ExitedAt: time.Now(), ExitCode: 255})
@@ -675,25 +710,18 @@ func (p *execProcess) LogWriter() io.Writer {
 }
 
 func (p *execProcess) getPid(context.Context) (uint32, error) {
-	data, err := os.ReadFile(p.pidFile())
+	pid, err := parsePidFile(p.pidFile())
 	if err != nil {
-		var state pState
-		if stateErr := p.readExitState(&state); stateErr == nil && state.Pid > 0 &&
-			(state.Status == "running" || state.Status == "exited") {
-			// systemd can remove PIDFile before Start observes it. A running or
-			// exited helper state proves runc created the workload.
+		// systemd removes PIDFile once the unit is dead, which a workload that
+		// exits immediately reaches before Start observes it. The state loaded
+		// from systemd still names the workload -- except for an exited-init,
+		// where runc never produced one and a pid must not be invented.
+		if state := p.ProcessState(); state.Pid > 0 && state.Status != exitedInit {
 			return state.Pid, nil
 		}
 		return 0, fmt.Errorf("read exec pid file: %w", err)
 	}
-	pid, err := strconv.ParseUint(strings.TrimSpace(string(data)), 10, 32)
-	if err != nil {
-		return 0, fmt.Errorf("parse exec pid: %w", err)
-	}
-	if pid == 0 {
-		return 0, fmt.Errorf("exec pid file contains zero")
-	}
-	return uint32(pid), nil
+	return pid, nil
 }
 
 // finishStart mirrors initProcess.finishStart for an exec process.

--- a/process_test.go
+++ b/process_test.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"os"
 	"path/filepath"
@@ -104,12 +103,12 @@ func TestRuncCommandArguments(t *testing.T) {
 }
 
 func TestExecProcessPIDFallback(t *testing.T) {
-	for _, status := range []string{"running", "exited"} {
-		t.Run("a "+status+" helper state supplies the workload PID after systemd removes PIDFile", func(t *testing.T) {
+	for _, status := range []string{"running", "exited", "failed"} {
+		t.Run("a "+status+" state supplies the workload PID after systemd removes PIDFile", func(t *testing.T) {
 			parent, _ := newTestInitProcess("container")
 			parent.Bundle = t.TempDir()
 			exec := newTestExecProcess(parent, "exec")
-			writeTestProcessState(t, exec.exitStatePath(), pState{Pid: 42, Status: status})
+			exec.SetState(context.Background(), pState{Pid: 42, Status: status})
 
 			pid, err := exec.getPid(context.Background())
 			if err != nil {
@@ -125,7 +124,17 @@ func TestExecProcessPIDFallback(t *testing.T) {
 		parent, _ := newTestInitProcess("container")
 		parent.Bundle = t.TempDir()
 		exec := newTestExecProcess(parent, "exec")
-		writeTestProcessState(t, exec.exitStatePath(), pState{Pid: 42, Status: exitedInit})
+		exec.SetState(context.Background(), pState{Pid: 42, Status: exitedInit})
+
+		if _, err := exec.getPid(context.Background()); err == nil {
+			t.Fatal("expected missing workload PID to fail")
+		}
+	})
+
+	t.Run("a process that never ran reports no PID", func(t *testing.T) {
+		parent, _ := newTestInitProcess("container")
+		parent.Bundle = t.TempDir()
+		exec := newTestExecProcess(parent, "exec")
 
 		if _, err := exec.getPid(context.Background()); err == nil {
 			t.Fatal("expected missing workload PID to fail")
@@ -395,20 +404,6 @@ func newTestExecProcess(parent *initProcess, execID string) *execProcess {
 	ep.cond = sync.NewCond(&ep.mu)
 	ep.events.Send(context.Background(), &eventsapi.TaskExecStarted{ExecID: execID})
 	return ep
-}
-
-func writeTestProcessState(t *testing.T, path string, state pState) {
-	t.Helper()
-	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-		t.Fatalf("create process state directory: %v", err)
-	}
-	data, err := json.Marshal(state)
-	if err != nil {
-		t.Fatalf("marshal process state: %v", err)
-	}
-	if err := os.WriteFile(path, data, 0600); err != nil {
-		t.Fatalf("write process state: %v", err)
-	}
 }
 
 func newRuncStub(t *testing.T) string {

--- a/process_test.go
+++ b/process_test.go
@@ -142,6 +142,72 @@ func TestExecProcessPIDFallback(t *testing.T) {
 	})
 }
 
+// The create re-exec's argv puts the subcommand before its own flags:
+// `<exe> --bundle=B create --mounts=M --tty <runc> ...`. A single flag.Parse
+// stops at "create", so --mounts is never seen and is handed to exec as the
+// container command instead -- which fails the unit, and only on the
+// PrivateMounts path, since the other path has no --mounts to misplace.
+func TestParseShimCreateArgs(t *testing.T) {
+	runc := []string{"/bin/runc-stub", "--root", "/run/runc", "create", "--bundle=/b", "ctr"}
+
+	t.Run("the private-mounts argv yields the mount config and the runc command", func(t *testing.T) {
+		argv := append([]string{"--debug=false", "--bundle=/b", "create", "--mounts=/b/mounts.json"}, runc...)
+
+		bundle, mounts, tty, cmd, err := parseShimCreateArgs(argv)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if bundle != "/b" {
+			t.Fatalf("bundle = %q, want /b", bundle)
+		}
+		if mounts != "/b/mounts.json" {
+			t.Fatalf("mounts = %q, want /b/mounts.json", mounts)
+		}
+		if tty {
+			t.Fatal("tty set without --tty")
+		}
+		if !slices.Equal(cmd, runc) {
+			t.Fatalf("command = %q, want %q", cmd, runc)
+		}
+	})
+
+	t.Run("the shared-propagation argv carries no mount config", func(t *testing.T) {
+		argv := append([]string{"--debug=false", "--bundle=/b", "create"}, runc...)
+
+		_, mounts, _, cmd, err := parseShimCreateArgs(argv)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if mounts != "" {
+			t.Fatalf("mounts = %q, want empty", mounts)
+		}
+		if !slices.Equal(cmd, runc) {
+			t.Fatalf("command = %q, want %q", cmd, runc)
+		}
+	})
+
+	t.Run("a tty argv sets tty without consuming the runc command", func(t *testing.T) {
+		argv := append([]string{"--bundle=/b", "create", "--mounts=/b/mounts.json", "--tty"}, runc...)
+
+		_, mounts, tty, cmd, err := parseShimCreateArgs(argv)
+		if err != nil {
+			t.Fatalf("parse: %v", err)
+		}
+		if !tty || mounts != "/b/mounts.json" {
+			t.Fatalf("tty = %v, mounts = %q", tty, mounts)
+		}
+		if !slices.Equal(cmd, runc) {
+			t.Fatalf("command = %q, want %q", cmd, runc)
+		}
+	})
+
+	t.Run("argv without a command is rejected", func(t *testing.T) {
+		if _, _, _, _, err := parseShimCreateArgs([]string{"--bundle=/b", "create", "--mounts=/b/m.json"}); err == nil {
+			t.Fatal("expected an argv with no runc command to be rejected")
+		}
+	})
+}
+
 func TestInitExitCleanup(t *testing.T) {
 	t.Run("a private PID namespace relies on kernel cleanup", func(t *testing.T) {
 		spec := &specs.Spec{Linux: &specs.Linux{

--- a/runc_stub_test.go
+++ b/runc_stub_test.go
@@ -91,26 +91,44 @@ func runShimCreateHelper() error {
 		}
 	}
 
-	flags := flag.NewFlagSet(shimCreateHelperName, flag.ContinueOnError)
-	flags.Bool("debug", false, "")
-	bundle := flags.String("bundle", "", "")
-	tty := flags.Bool("tty", false, "")
-	mounts := flags.String("mounts", "", "")
-	if err := flags.Parse(os.Args[1:]); err != nil {
+	bundle, mounts, tty, cmd, err := parseShimCreateArgs(os.Args[1:])
+	if err != nil {
 		return err
 	}
-
-	args := flags.Args()
-	if len(args) < 2 || args[0] != "create" {
-		return fmt.Errorf("invalid shim helper arguments: %q", os.Args[1:])
-	}
 	// The PrivateMounts path mounts the rootfs in the create re-exec before runc.
-	if *mounts != "" {
-		if err := mountRootfs(*mounts); err != nil {
+	if mounts != "" {
+		if err := mountRootfs(mounts); err != nil {
 			return err
 		}
 	}
-	return createCmd(context.Background(), *bundle, args[1:], *tty, *mounts != "")
+	return createCmd(context.Background(), bundle, cmd, tty, mounts != "")
+}
+
+// parseShimCreateArgs mirrors main()'s two-stage parse: global flags up to the
+// subcommand, then the subcommand's own flags. A single pass would stop at
+// "create" and leave --mounts= to be exec'd as the container command, which is
+// exactly the shape the PrivateMounts path produces.
+func parseShimCreateArgs(argv []string) (bundle, mounts string, tty bool, cmd []string, err error) {
+	rootFlags := flag.NewFlagSet(shimCreateHelperName, flag.ContinueOnError)
+	rootFlags.Bool("debug", false, "")
+	rootBundle := rootFlags.String("bundle", "", "")
+	if err := rootFlags.Parse(argv); err != nil {
+		return "", "", false, nil, err
+	}
+	if rootFlags.NArg() < 1 || rootFlags.Arg(0) != "create" {
+		return "", "", false, nil, fmt.Errorf("invalid shim helper arguments: %q", argv)
+	}
+
+	subFlags := flag.NewFlagSet(shimCreateHelperName+" create", flag.ContinueOnError)
+	subTTY := subFlags.Bool("tty", false, "")
+	subMounts := subFlags.String("mounts", "", "")
+	if err := subFlags.Parse(rootFlags.Args()[1:]); err != nil {
+		return "", "", false, nil, err
+	}
+	if subFlags.NArg() < 1 {
+		return "", "", false, nil, fmt.Errorf("invalid shim helper arguments: %q", argv)
+	}
+	return *rootBundle, *subMounts, *subTTY, subFlags.Args(), nil
 }
 
 func runRuncStub() int {

--- a/service_integration_test.go
+++ b/service_integration_test.go
@@ -506,53 +506,231 @@ func TestServiceTaskRestoreAgainstSystemd(t *testing.T) {
 // and the unmount is checked after delete. (The PrivateMounts variant's property
 // construction is covered by TestInitProcessRootfsMountProperties; its runtime
 // needs cross-namespace runc state the in-process stub cannot model.)
-func TestServiceTaskRootfsMountAgainstSystemd(t *testing.T) {
+// TestServiceUnitNotifyPropertiesAgainstSystemd pins the notify configuration
+// the shim's exit reporting depends on, for both unit kinds.
+//
+// Type=notify alone is not enough. It implies NotifyAccess=main, and once
+// systemd accepts MAINPID= the workload is the main process -- so the create
+// re-exec's report of a workload that died during the handoff is refused, and
+// systemd has no record of that exit either because the re-exec reaped it. The
+// exit status is lost outright. Dropping NotifyAccess=all would not fail any
+// other test in this suite; it would just start losing exit codes under load.
+func TestServiceUnitNotifyPropertiesAgainstSystemd(t *testing.T) {
 	h := newServiceIntegrationHarness(t)
-	requireBindMount(t)
-
-	const marker = "mounted"
-	src := t.TempDir()
-	if err := os.WriteFile(filepath.Join(src, marker), nil, 0600); err != nil {
-		t.Fatalf("write rootfs marker: %v", err)
+	ctx, req, initUnit := h.task(t, "notify-props", runcStubConfig{ExitDelay: 30 * time.Second})
+	if _, err := h.service.Create(ctx, req); err != nil {
+		t.Fatalf("create task: %v", err)
+	}
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+		t.Fatalf("start task: %v", err)
+	}
+	execUnit := h.exec(t, ctx, req, "notify-props-exec", runcStubConfig{ExitDelay: 30 * time.Second})
+	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID, ExecID: "notify-props-exec"}); err != nil {
+		t.Fatalf("start exec: %v", err)
 	}
 
-	ctx, req, _ := h.task(t, "rootfs-mount", runcStubConfig{ExitDelay: 100 * time.Millisecond}, func(s *specs.Spec) {
-		s.Annotations[runcStubRootfsMarkerAnnotation] = marker
-		s.Linux.RootfsPropagation = "shared" // selects the no-new-namespace path
-	})
-	req.Rootfs = []*types.Mount{{Type: "bind", Source: src, Options: []string{"rbind"}}}
-	rootfs := filepath.Join(req.Bundle, "rootfs")
+	for name, unit := range map[string]string{"a container unit": initUnit, "an exec unit": execUnit} {
+		t.Run(name+" accepts the create re-exec's reports after the main pid moves", func(t *testing.T) {
+			props, err := h.conn.GetAllPropertiesContext(ctx, unit)
+			if err != nil {
+				t.Fatalf("read unit properties: %v", err)
+			}
+			if got := props["Type"]; got != "notify" {
+				t.Fatalf("unit Type = %v, want notify", got)
+			}
+			if got := props["NotifyAccess"]; got != "all" {
+				t.Fatalf("unit NotifyAccess = %v, want all", got)
+			}
+		})
+	}
+
+	if _, err := h.service.Kill(ctx, &taskapi.KillRequest{ID: req.ID, Signal: uint32(unix.SIGKILL), All: true}); err != nil {
+		t.Fatalf("kill task: %v", err)
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	if _, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID}); err != nil {
+		t.Fatalf("wait for task: %v", err)
+	}
+	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID, ExecID: "notify-props-exec"}); err != nil {
+		t.Fatalf("delete exec: %v", err)
+	}
+	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
+		t.Fatalf("delete task: %v", err)
+	}
+}
+
+// TestServiceWaitRecoversMissedExitAgainstSystemd is the counterpart to
+// TestServiceTaskMissedExitSignalAgainstSystemd for the Wait path. Wait skips
+// its property read while the signal stream is up, on the grounds that nothing
+// can have been missed; with the stream down that reasoning does not hold, so it
+// must still look. waitForExit parks in sync.Cond.Wait, which no context can
+// interrupt, so a regression here hangs rather than failing.
+func TestServiceWaitRecoversMissedExitAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+	ctx, req, unit := h.task(t, "missed-exit-wait", runcStubConfig{ExitCode: 7, ExitDelay: 300 * time.Millisecond})
 
 	if _, err := h.service.Create(ctx, req); err != nil {
 		t.Fatalf("create task: %v", err)
 	}
-	// ExecStartPre mounted the rootfs in the host namespace.
-	if _, err := os.Stat(filepath.Join(rootfs, marker)); err != nil {
-		t.Fatalf("rootfs not mounted in host namespace: %v", err)
-	}
-
 	if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
 		t.Fatalf("start task: %v", err)
 	}
 
-	// A clean zero exit proves the container saw its mounted rootfs; a missing
-	// mount would have exited runcStubRootfsMissing instead.
-	waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
-	if err != nil {
-		t.Fatalf("wait for task: %v", err)
+	// Drop the stream before the workload exits, so nothing reconciles it.
+	h.stopReactor()
+
+	if !eventually(15*time.Second, 20*time.Millisecond, func() bool {
+		st, err := loadExitFromUnit(ctx, h.conn, unit)
+		return err == nil && st.Exited()
+	}) {
+		t.Fatal("unit never exited in systemd")
 	}
-	if waited.ExitStatus != 0 {
-		t.Fatalf("task exit status = %d, want 0 (container saw the rootfs marker)", waited.ExitStatus)
+	if h.service.processes.Get(path.Join(h.namespace, req.ID)).ProcessState().Exited() {
+		t.Skip("shim recorded the exit without the event stream; cannot exercise the missed-signal path")
+	}
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	type waitResult struct {
+		resp *taskapi.WaitResponse
+		err  error
+	}
+	done := make(chan waitResult, 1)
+	go func() {
+		resp, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
+		done <- waitResult{resp, err}
+	}()
+
+	select {
+	case res := <-done:
+		if res.err != nil {
+			t.Fatalf("wait for task: %v", res.err)
+		}
+		if res.resp.ExitStatus != 7 {
+			t.Errorf("wait reported exit status %d, want 7 recovered from the still-loaded unit", res.resp.ExitStatus)
+		}
+	case <-time.After(30 * time.Second):
+		t.Fatal("wait blocked: the exit on the still-loaded unit was never read with the stream down")
 	}
 
 	if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
 		t.Fatalf("delete task: %v", err)
 	}
-	// ExecStopPost unmounted the rootfs, so the host no longer sees it.
-	if _, err := os.Stat(filepath.Join(rootfs, marker)); !os.IsNotExist(err) {
-		t.Fatalf("rootfs still mounted after delete: %v", err)
+}
+
+// TestServiceTaskRootfsMountFailureAgainstSystemd covers the unit failing before
+// it ever has a main process. ExecStartPre mounts the rootfs on the
+// no-new-namespace path, and a mount that cannot succeed fails the unit while
+// ExecMainPID is still 0 -- properties identical to a unit that has not started
+// yet, apart from Result. Reading that as "not started" makes Create report
+// success with pid 0 for a container whose rootfs was never mounted.
+//
+// Unlike the success path this needs no privileges: the mount has to fail, and
+// it fails unprivileged just as well.
+func TestServiceTaskRootfsMountFailureAgainstSystemd(t *testing.T) {
+	h := newServiceIntegrationHarness(t)
+
+	ctx, req, _ := h.task(t, "rootfs-mount-failure", runcStubConfig{}, func(s *specs.Spec) {
+		s.Linux.RootfsPropagation = "shared" // selects the ExecStartPre mount path
+	})
+	req.Rootfs = []*types.Mount{{
+		Type:    "bind",
+		Source:  filepath.Join(t.TempDir(), "does-not-exist"),
+		Options: []string{"rbind"},
+	}}
+
+	created, err := h.service.Create(ctx, req)
+	if err == nil {
+		t.Fatalf("create succeeded with an unmountable rootfs, pid %d", created.Pid)
+	}
+
+	state, err := h.service.State(ctx, &taskapi.StateRequest{ID: req.ID})
+	if err != nil {
+		// Create may have torn the task down entirely, which is also a correct
+		// answer -- what must not happen is a live task with no exit.
+		return
+	}
+	if state.Status != tasktypes.Status_STOPPED {
+		t.Fatalf("task status = %s, want stopped after a failed rootfs mount", state.Status)
+	}
+	if state.ExitStatus == 0 {
+		t.Fatal("task reported exit status 0 after a failed rootfs mount")
+	}
+}
+
+func TestServiceTaskRootfsMountAgainstSystemd(t *testing.T) {
+	requireBindMount(t)
+
+	// The two rootfs paths differ in who mounts and where. A shared propagation
+	// keeps the container in the host mount namespace, so ExecStartPre mounts
+	// the rootfs where the host can see it. Otherwise the unit gets
+	// PrivateMounts and the create re-exec mounts inside it, invisible to the
+	// host -- and that re-exec cannot reap the workload, so it reports readiness
+	// and nothing else.
+	for _, tc := range []struct {
+		name        string
+		specOpt     func(*specs.Spec)
+		hostMounted bool
+	}{
+		{
+			name:        "a shared rootfs propagation mounts the rootfs where the host can see it",
+			specOpt:     func(s *specs.Spec) { s.Linux.RootfsPropagation = "shared" },
+			hostMounted: true,
+		},
+		{
+			name:        "a private mount namespace mounts the rootfs inside the unit",
+			specOpt:     func(s *specs.Spec) {},
+			hostMounted: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			h := newServiceIntegrationHarness(t)
+
+			const marker = "mounted"
+			src := t.TempDir()
+			if err := os.WriteFile(filepath.Join(src, marker), nil, 0600); err != nil {
+				t.Fatalf("write rootfs marker: %v", err)
+			}
+
+			ctx, req, _ := h.task(t, "rootfs-mount", runcStubConfig{ExitDelay: 100 * time.Millisecond}, func(s *specs.Spec) {
+				s.Annotations[runcStubRootfsMarkerAnnotation] = marker
+				tc.specOpt(s)
+			})
+			req.Rootfs = []*types.Mount{{Type: "bind", Source: src, Options: []string{"rbind"}}}
+			rootfs := filepath.Join(req.Bundle, "rootfs")
+
+			if _, err := h.service.Create(ctx, req); err != nil {
+				t.Fatalf("create task: %v", err)
+			}
+			if _, err := os.Stat(filepath.Join(rootfs, marker)); tc.hostMounted != (err == nil) {
+				t.Fatalf("rootfs visible in host namespace = %v, want %v (%v)", err == nil, tc.hostMounted, err)
+			}
+
+			if _, err := h.service.Start(ctx, &taskapi.StartRequest{ID: req.ID}); err != nil {
+				t.Fatalf("start task: %v", err)
+			}
+
+			// A clean zero exit proves the container saw its mounted rootfs; a
+			// missing mount would have exited runcStubRootfsMissing instead.
+			waitCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+			defer cancel()
+			waited, err := h.service.Wait(waitCtx, &taskapi.WaitRequest{ID: req.ID})
+			if err != nil {
+				t.Fatalf("wait for task: %v", err)
+			}
+			if waited.ExitStatus != 0 {
+				t.Fatalf("task exit status = %d, want 0 (container saw the rootfs marker)", waited.ExitStatus)
+			}
+
+			if _, err := h.service.Delete(ctx, &taskapi.DeleteRequest{ID: req.ID}); err != nil {
+				t.Fatalf("delete task: %v", err)
+			}
+			// ExecStopPost unmounted the rootfs, so the host no longer sees it.
+			if _, err := os.Stat(filepath.Join(rootfs, marker)); !os.IsNotExist(err) {
+				t.Fatalf("rootfs still mounted after delete: %v", err)
+			}
+		})
 	}
 }
 
@@ -702,7 +880,12 @@ func newServiceIntegrationHarness(t *testing.T) *serviceIntegrationHarness {
 		reactor := newEventReactor(service.units)
 		stop := reactor.start(reactorCtx)
 		defer stop()
+		// Mirror runEventReactor: while the stream is up, callers trust in-memory
+		// state instead of reading systemd. stopReactor waits for this goroutine,
+		// so the flag is false by the time a test that drops the stream proceeds.
+		service.reactorUp.Store(true)
 		reactor.consume(reactorCtx, unitUpdates(reactorCtx, signals))
+		service.reactorUp.Store(false)
 	}()
 
 	var stopReactorOnce sync.Once
@@ -761,8 +944,7 @@ func (h *serviceIntegrationHarness) task(t *testing.T, id string, cfg runcStubCo
 	}
 
 	createOptions, err := typeurl.MarshalAnyToProto(&options.CreateOptions{
-		LogMode:        options.LogMode_NULL,
-		SdNotifyEnable: true,
+		LogMode: options.LogMode_NULL,
 	})
 	if err != nil {
 		t.Fatalf("marshal create options: %v", err)

--- a/start.go
+++ b/start.go
@@ -120,14 +120,14 @@ func (p *initProcess) startProperties(rcmd []string) ([]systemd.Property, error)
 		"STDOUT_FIFO=" + p.Stdout,
 		"STDERR_FIFO=" + p.Stderr,
 		"UNIT_NAME=" + p.Name(),
-		"EXIT_STATE_PATH=" + p.exitStatePath(),
 	}
 	if p.shimCgroup != "" {
 		env = append(env, "SHIM_CGROUP="+p.shimCgroup)
 	}
 
 	props := []systemd.Property{
-		systemd.PropType(p.unitType()),
+		systemd.PropType("notify"),
+		propNotifyAccess(),
 		systemd.PropRemainAfterExit(false),
 		{Name: "WorkingDirectory", Value: dbus.MakeVariant(p.Bundle)},
 		{Name: "PIDFile", Value: dbus.MakeVariant(p.pidFile())},
@@ -174,7 +174,6 @@ func (p *execProcess) startProperties() ([]systemd.Property, error) {
 		"STDOUT_FIFO=" + p.Stdout,
 		"STDERR_FIFO=" + p.Stderr,
 		"UNIT_NAME=" + p.Name(),
-		"EXIT_STATE_PATH=" + p.exitStatePath(),
 	}
 	if p.shimCgroup != "" {
 		env = append(env, "SHIM_CGROUP="+p.shimCgroup)
@@ -182,6 +181,7 @@ func (p *execProcess) startProperties() ([]systemd.Property, error) {
 
 	props := []systemd.Property{
 		systemd.PropType("notify"),
+		propNotifyAccess(),
 		systemd.PropRemainAfterExit(false),
 		{Name: "WorkingDirectory", Value: dbus.MakeVariant(p.parent.Bundle)},
 		{Name: "PIDFile", Value: dbus.MakeVariant(p.pidFile())},
@@ -215,11 +215,21 @@ func (p *execProcess) startProperties() ([]systemd.Property, error) {
 	return props, nil
 }
 
-func (p *process) unitType() string {
-	if p.opts.SdNotifyEnable {
-		return "notify"
-	}
-	return "forking"
+// propNotifyAccess allows the create re-exec to keep reporting after it has
+// handed the main pid over.
+//
+// `Type=notify` implies `NotifyAccess=main`, which is not enough. Once systemd
+// accepts `MAINPID=`, the workload is the main process and the re-exec's
+// notifications are refused -- including the one that matters most, the report
+// of a workload that died while the handoff was in flight. systemd has no
+// record of that exit either, because the re-exec is the subreaper and reaped
+// it, so refusing the report loses the exit status outright.
+//
+// The workload cannot abuse the wider access: NOTIFY_SOCKET is a filesystem
+// socket that is not in the container's mount namespace, and the container's
+// environment comes from the OCI spec rather than the unit.
+func propNotifyAccess() systemd.Property {
+	return systemd.Property{Name: "NotifyAccess", Value: dbus.MakeVariant("all")}
 }
 
 // abandonStartedUnit tears down a unit whose process was deleted while it was
@@ -290,18 +300,18 @@ func (p *initProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 		if !p.ProcessState().Exited() {
 			log.G(ctx).Debug("runc start failed but process is still running, sending sigkill")
 			p.systemd.KillUnitContext(ctx, p.Name(), int32(unix.SIGKILL))
-			if err := p.LoadState(ctx); err != nil {
-				log.G(ctx).WithError(err).Debug("Error loading process state")
-			}
 
-			if !p.ProcessState().Exited() {
-				p.SetState(ctx, pState{
-					Pid:      p.Pid(),
-					ExitCode: 255,
-					ExitedAt: time.Now(),
-					Status:   "failed",
-				})
-			}
+			// The workload never ran, so the exit of the process the shim just
+			// killed is the shim's own doing rather than the task's result.
+			// Reading it back would make a failed start report 137 or 255
+			// depending only on whether the kill landed before the read, so
+			// record the failure instead.
+			p.SetState(ctx, pState{
+				Pid:      p.Pid(),
+				ExitCode: 255,
+				ExitedAt: time.Now(),
+				Status:   "failed",
+			})
 		}
 		p.cond.Broadcast()
 
@@ -323,18 +333,10 @@ func (p *initProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 		return 0, ret
 	}
 
-	for p.Pid() == 0 && !p.ProcessState().Exited() {
-		select {
-		case <-ctx.Done():
-		default:
-		}
-
-		if err := p.LoadState(ctx); err != nil {
-			log.G(ctx).WithError(err).Warn("Error loading process state")
-		}
+	if pid = p.Pid(); pid == 0 {
+		return 0, fmt.Errorf("could not get container pid: %s", p.ProcessState())
 	}
 
-	pid = p.Pid()
 	return pid, nil
 }
 
@@ -496,22 +498,32 @@ func (p *execProcess) Start(ctx context.Context) (pid uint32, retErr error) {
 		}
 	}
 
-	p.LoadState(ctx)
-
-	if p.ProcessState().Status == exitedInit {
-		ret := fmt.Errorf("error starting exec process")
-		if p.runc.Debug {
-			debug, err := os.ReadFile(p.runc.Log)
-			if err == nil {
-				ret = fmt.Errorf("%w:\nrunc debug:\n%s", ret, string(debug))
-			}
-		}
-		return 0, ret
-	}
-
+	// No state read on the way in. The unit is Type=notify, so "done" means the
+	// create re-exec sent READY=1, which it only does once runc has left a
+	// workload behind -- and that means a pid file. Its absence, not a property
+	// read, is what says runc failed.
 	pid, err = p.getPid(ctx)
 	if err != nil {
-		return 0, err
+		// runc left no pid, so ask systemd why. An exited-init is runc's own
+		// failure; anything else means the workload ran and exited fast enough
+		// that systemd unlinked PIDFile, in which case the state just loaded
+		// still names it.
+		if lerr := p.LoadState(ctx); lerr != nil {
+			log.G(ctx).WithError(lerr).Warn("Error loading process state")
+		}
+		if p.ProcessState().Status == exitedInit {
+			ret := fmt.Errorf("error starting exec process")
+			if p.runc.Debug {
+				debug, derr := os.ReadFile(p.runc.Log)
+				if derr == nil {
+					ret = fmt.Errorf("%w:\nrunc debug:\n%s", ret, string(debug))
+				}
+			}
+			return 0, ret
+		}
+		if pid, err = p.getPid(ctx); err != nil {
+			return 0, err
+		}
 	}
 
 	p.mu.Lock()

--- a/state.go
+++ b/state.go
@@ -2,11 +2,10 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"path"
-	"path/filepath"
+	"strconv"
+	"strings"
 	"time"
 
 	taskapi "github.com/containerd/containerd/api/runtime/task/v3"
@@ -85,9 +84,27 @@ func getUnitState(ctx context.Context, conn *dbus.Conn, unit string, st *pState)
 	if err != nil {
 		return err
 	}
+	applyUnitProperties(state, st)
+	return nil
+}
 
-	if p := state["ExecMainPID"]; p != nil {
-		st.Pid = uint32(p.(uint32))
+// applyUnitProperties folds a unit's systemd properties into st. It is the
+// property-read counterpart of serviceExitState, which decodes the same facts
+// out of a signal, and is separate from the read itself so the precedence
+// between the two accounts of an exit is testable without a bus.
+func applyUnitProperties(state map[string]interface{}, st *pState) {
+	if status := state["SubState"]; status != nil {
+		st.Status = status.(string)
+	}
+
+	// ExecMainPID is the create re-exec's own pid until it hands the workload
+	// over with MAINPID=, which for a notify unit is the moment the unit
+	// finishes activating. Reading it before then latches the re-exec's pid as
+	// the task's, and the first pid the shim records is the one it keeps.
+	if !activatingSubState(st.Status) {
+		if p := state["ExecMainPID"]; p != nil {
+			st.Pid = uint32(p.(uint32))
+		}
 	}
 	// systemd reports a killed main process as the bare signal number, with
 	// ExecMainCode carrying the si_code that says so.
@@ -99,28 +116,92 @@ func getUnitState(ctx context.Context, conn *dbus.Conn, unit string, st *pState)
 		st.ExitCode = exitStatusFor(mainCode, c.(int32))
 	}
 
-	// if ts := state["ExecMainExitTimestamp"]; ts != nil {
-	// st.ExitedAt = time.UnixMicro(int64(ts.(uint64)))
-	// if !st.ExitedAt.After(timeZero) {
-	if st.ExitCode == 0 {
-		execStart := state["ExecStart"].([][]interface{})
-		if len(execStart) > 0 {
-			code, _ := readExecStatusExit(state["ExecStart"].([][]interface{})[0])
-			// if t.After(timeZero) {
-			// st.ExitedAt = t
-			if code > 0 {
-				st.ExitCode = uint32(code)
-			}
+	if ts := state["ExecMainExitTimestamp"]; ts != nil {
+		if micros := ts.(uint64); micros > 0 {
+			st.ExitedAt = time.UnixMicro(int64(micros))
 		}
-		// }
-	}
-	//}
-	// }
-	if status := state["SubState"]; status != nil {
-		st.Status = status.(string)
 	}
 
-	return nil
+	// The create re-exec's own report comes last because it is the only source
+	// for an exit systemd did not witness: when the re-exec reaped the workload
+	// itself, ExecMainPID/Code/Status describe the re-exec rather than the
+	// workload, and SubState only says the unit is dead.
+	if v := state["StatusText"]; v != nil {
+		if status, pid := parseStatusText(v.(string)); status == exitedInit || status == "exited" {
+			st.Status = status
+			st.Pid = pid
+			st.ExitCode = 0
+			if e := state["StatusErrno"]; e != nil {
+				if errno := e.(int32); errno > 0 {
+					st.ExitCode = uint32(errno)
+				}
+			}
+		}
+	}
+
+	// A unit that has not started yet reads exactly like one that failed before it
+	// ever had a main process: inactive/dead, no main pid, no exit code. Result
+	// tells them apart -- it stays "success" until something actually fails.
+	//
+	// Getting this wrong in either direction is a real bug: reporting the
+	// pre-start state as an exit kills a container before runc runs, and
+	// discarding a genuine early failure (an ExecStartPre that is not allowed to
+	// fail, say) leaves the task looking alive with nothing left to report it.
+	if st.Pid == 0 && st.ExitCode == 0 && toStatus(st.Status) == task.Status_STOPPED {
+		if unitFailed(state) {
+			// No workload ran, so there is no exit code to report. 255 is the
+			// shim's code for a failure of its own making.
+			st.ExitCode = 255
+		} else {
+			st.Reset()
+		}
+	}
+
+	// A terminal state is worth nothing to containerd without an exit time, and
+	// a report the create re-exec sent carries none of its own. Stamping the
+	// read is the closest available: the exit it describes has only just
+	// happened.
+	if st.Exited() && !st.ExitedAt.After(timeZero) {
+		st.ExitedAt = time.Now()
+	}
+}
+
+// unitFailed reports whether systemd's Result says the unit failed. It reads
+// "success" both for a unit that has not run yet and for one that ran cleanly,
+// and systemd sets it only after applying the "-" ignore-failure prefix on Exec*
+// commands -- so a command that is allowed to fail never shows up here.
+func unitFailed(state map[string]interface{}) bool {
+	result, _ := state["Result"].(string)
+	return result != "" && result != "success"
+}
+
+// activatingSubState reports whether a service SubState is one systemd uses
+// while the unit is still starting, so its main process is the create re-exec
+// rather than the workload the re-exec is bringing up.
+func activatingSubState(s string) bool {
+	switch s {
+	case "start-pre", "start":
+		return true
+	}
+	return false
+}
+
+// parseStatusText splits the STATUS= text notifyStatus sends into the status
+// and the pid it belongs to.
+//
+// Text without a usable pid yields the status alone rather than an error: the
+// status is what says the workload exited, and losing the pid is better than
+// losing the exit.
+func parseStatusText(s string) (status string, pid uint32) {
+	status, rest, ok := strings.Cut(s, " ")
+	if !ok {
+		return status, 0
+	}
+	v, err := strconv.ParseUint(rest, 10, 32)
+	if err != nil {
+		return status, 0
+	}
+	return status, uint32(v)
 }
 
 type State struct {
@@ -150,17 +231,6 @@ func (p *initProcess) State(ctx context.Context) (*State, error) {
 
 func (p *initProcess) LoadState(ctx context.Context) error {
 	var st pState
-	if err := p.readExitState(&st); err == nil {
-		if st.Pid > 0 && st.Status == "" {
-			st.Status = "running"
-		}
-		p.SetState(ctx, st)
-		return nil
-	} else if p.Pid() == 0 {
-		// Nothing to load
-		return nil
-	}
-
 	st.Reset()
 	if err := getUnitState(ctx, p.systemd, p.Name(), &st); err != nil {
 		return err
@@ -171,102 +241,48 @@ func (p *initProcess) LoadState(ctx context.Context) error {
 
 func (p *execProcess) LoadState(ctx context.Context) error {
 	var st pState
-	err := p.readExitState(&st)
-	if err == nil {
-		p.SetState(ctx, st)
-		return nil
+	st.Reset()
+	if err := getUnitState(ctx, p.systemd, p.Name(), &st); err != nil {
+		return err
 	}
-
-	if !os.IsNotExist(err) {
-		log.G(ctx).WithField("unit", p.Name()).WithError(err).Debug("Error reading exit state file")
-	}
+	p.SetState(ctx, st)
 	return nil
 }
 
-// loadExitFromUnit is the fallback when the signal stream did not record a
-// terminal Service update. It reads ExecMainStatus and SubState while the unit
-// is still loaded. getUnitState leaves ExitedAt unset, so stamp it for a clean
-// exit whose code is 0 (its exited status still comes through SubState).
+// loadExitFromUnit reads a unit's terminal state directly, for callers that have
+// no recorded exit to fall back on -- delete, which has just stopped the unit
+// itself, and the tests that assert against systemd.
 func loadExitFromUnit(ctx context.Context, conn *dbus.Conn, name string) (pState, error) {
 	var st pState
 	st.Reset()
 	if err := getUnitState(ctx, conn, name, &st); err != nil {
 		return pState{}, err
 	}
-	if st.Exited() && !st.ExitedAt.After(timeZero) {
-		st.ExitedAt = time.Now()
-	}
 	return st, nil
 }
 
-func (p *initProcess) LoadExitState(ctx context.Context) error {
-	if st, ok := p.loadRecordedSystemdExitState(); ok {
-		countState(metricReactorHits)
-		p.SetState(ctx, st)
-		return nil
+// LoadRecordedExitState applies the terminal state the reactor decoded from the
+// unit's own signal, and reports whether there was one. It does no I/O: the
+// signal that enqueued a unit already carried the exit, so a reconcile can
+// answer from it rather than asking systemd for what it has already been told.
+func (p *initProcess) LoadRecordedExitState(ctx context.Context) bool {
+	st, ok := p.loadRecordedSystemdExitState()
+	if !ok {
+		return false
 	}
-	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
-	if err != nil {
-		return err
-	}
-	// Count a fallback only when GetAll actually recovered a terminal exit the
-	// reactor missed; a pre-start / non-terminal read is not a reactor miss.
-	if st.Exited() {
-		countState(metricGetAllFallbacks)
-	}
+	countState(metricReactorHits)
 	p.SetState(ctx, st)
-	return nil
+	return true
 }
 
-func (p *execProcess) LoadExitState(ctx context.Context) error {
-	if st, ok := p.loadRecordedSystemdExitState(); ok {
-		countState(metricReactorHits)
-		p.SetState(ctx, st)
-		return nil
+func (p *execProcess) LoadRecordedExitState(ctx context.Context) bool {
+	st, ok := p.loadRecordedSystemdExitState()
+	if !ok {
+		return false
 	}
-	st, err := loadExitFromUnit(ctx, p.systemd, p.Name())
-	if err != nil {
-		return err
-	}
-	// Count a fallback only when GetAll actually recovered a terminal exit the
-	// reactor missed; a pre-start / non-terminal read is not a reactor miss.
-	if st.Exited() {
-		countState(metricGetAllFallbacks)
-	}
+	countState(metricReactorHits)
 	p.SetState(ctx, st)
-	return nil
-}
-
-func (p *execProcess) exitStatePath() string {
-	return filepath.Join(p.stateDir(), "exit_status.json")
-}
-
-func (p *execProcess) readExitState(st *pState) error {
-	data, err := os.ReadFile(p.exitStatePath())
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, st); err != nil {
-		return err
-	}
-	countState(metricOnDiskReads)
-	return nil
-}
-
-func (p *initProcess) exitStatePath() string {
-	return filepath.Join(p.Bundle, "init_exit_status.json")
-}
-
-func (p *initProcess) readExitState(st *pState) error {
-	data, err := os.ReadFile(p.exitStatePath())
-	if err != nil {
-		return err
-	}
-	if err := json.Unmarshal(data, st); err != nil {
-		return err
-	}
-	countState(metricOnDiskReads)
-	return nil
+	return true
 }
 
 func (p *execProcess) State(ctx context.Context) (*State, error) {
@@ -421,10 +437,6 @@ type execState struct {
 	Args       []string
 	Pid        uint32
 	StatusCode uint32 // This is the systemd status (e.g. "exited")
-}
-
-func readExecStatusExit(i []interface{}) (uint32, time.Time) {
-	return uint32(i[9].(int32)), time.UnixMicro(int64(i[5].(uint64)))
 }
 
 func parseExecStartStatus(ii [][]interface{}, st *execState) error {

--- a/state_recorded_exit_test.go
+++ b/state_recorded_exit_test.go
@@ -25,8 +25,8 @@ func TestLoadExitStateUsesRecordedSystemdState(t *testing.T) {
 			Status:   "exited",
 		})
 
-		if err := exec.LoadExitState(context.Background()); err != nil {
-			t.Fatalf("load recorded exit state: %v", err)
+		if !exec.LoadRecordedExitState(context.Background()) {
+			t.Fatal("no exit state was recorded to load")
 		}
 
 		state := exec.ProcessState()
@@ -49,8 +49,8 @@ func TestLoadExitStateUsesRecordedSystemdState(t *testing.T) {
 		exec.RecordSystemdExitState(pState{Pid: 41, ExitCode: 1, ExitedAt: earlier, Status: "exited"})
 		exec.RecordSystemdExitState(pState{Pid: 42, ExitCode: 17, ExitedAt: later, Status: "exited"})
 
-		if err := exec.LoadExitState(context.Background()); err != nil {
-			t.Fatalf("load latest recorded exit state: %v", err)
+		if !exec.LoadRecordedExitState(context.Background()) {
+			t.Fatal("no exit state was recorded to load")
 		}
 
 		state := exec.ProcessState()
@@ -58,4 +58,62 @@ func TestLoadExitStateUsesRecordedSystemdState(t *testing.T) {
 			t.Fatalf("state = %s, want the later pid 42, exit 17, timestamp %s", state, later)
 		}
 	})
+
+	// The create re-exec is still the unit's main process when it reports, so
+	// the ExecMain properties systemd publishes moments later describe the
+	// re-exec's own exit. Letting those win reports the wrong code for every
+	// workload that exits before systemd can adopt its pid.
+	t.Run("a reported exit is not superseded by the unit's later systemd record", func(t *testing.T) {
+		exec := newRecordedExitTestExec()
+		reported := time.Now()
+		exec.RecordHelperExitState(pState{Pid: 42, ExitCode: 19, ExitedAt: reported, Status: "exited"})
+		exec.RecordSystemdExitState(pState{Pid: 7, ExitCode: 3, ExitedAt: reported.Add(time.Second), Status: "exited"})
+
+		if !exec.LoadRecordedExitState(context.Background()) {
+			t.Fatal("no exit state was recorded to load")
+		}
+
+		state := exec.ProcessState()
+		if state.Pid != 42 || state.ExitCode != 19 {
+			t.Fatalf("state = %s, want the reported pid 42 and exit 19", state)
+		}
+	})
+
+	t.Run("a reported init failure is not superseded either", func(t *testing.T) {
+		exec := newRecordedExitTestExec()
+		reported := time.Now()
+		exec.RecordHelperExitState(pState{ExitCode: 1, ExitedAt: reported, Status: exitedInit})
+		exec.RecordSystemdExitState(pState{Pid: 7, ExitCode: 3, ExitedAt: reported.Add(time.Second), Status: "exited"})
+
+		if !exec.LoadRecordedExitState(context.Background()) {
+			t.Fatal("no exit state was recorded to load")
+		}
+
+		if state := exec.ProcessState(); state.Status != exitedInit || state.ExitCode != 1 {
+			t.Fatalf("state = %s, want status %s and exit 1", state, exitedInit)
+		}
+	})
+
+	t.Run("restarting a process clears the report that outranked systemd", func(t *testing.T) {
+		exec := newRecordedExitTestExec()
+		exec.RecordHelperExitState(pState{Pid: 42, ExitCode: 19, ExitedAt: time.Now(), Status: "exited"})
+		exec.clearRecordedSystemdExitState()
+
+		if _, ok := exec.loadRecordedSystemdExitState(); ok {
+			t.Fatal("a cleared report was still recorded")
+		}
+
+		later := time.Now()
+		exec.RecordSystemdExitState(pState{Pid: 7, ExitCode: 3, ExitedAt: later, Status: "exited"})
+		if state, ok := exec.loadRecordedSystemdExitState(); !ok || state.ExitCode != 3 {
+			t.Fatalf("state = %s (recorded %v), want exit 3", state, ok)
+		}
+	})
+}
+
+func newRecordedExitTestExec() *execProcess {
+	parent := &initProcess{process: &process{id: "task", events: discardEvents()}}
+	process := &process{id: "exec", events: discardEvents()}
+	process.cond = sync.NewCond(&process.mu)
+	return &execProcess{process: process, parent: parent, execID: "exec"}
 }

--- a/state_test.go
+++ b/state_test.go
@@ -153,21 +153,188 @@ func TestPStateCopyTo(t *testing.T) {
 	})
 }
 
-func TestReadExecStatusExit(t *testing.T) {
-	t.Run("the exit code is read from field nine and the timestamp from field five", func(t *testing.T) {
-		exitedAtMicros := uint64(time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC).UnixMicro())
-		row := []interface{}{
-			"path", []string{"arg"}, false,
-			uint64(0), uint64(0), exitedAtMicros, uint64(0),
-			uint32(1234), int32(0), int32(37),
-		}
+func TestApplyUnitProperties(t *testing.T) {
+	t.Run("a running unit reports its main pid", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID": uint32(42),
+			"SubState":    "running",
+			"StatusText":  "",
+			"StatusErrno": int32(0),
+		}, &st)
 
-		code, exitedAt := readExecStatusExit(row)
-		if code != 37 {
-			t.Fatalf("expected exit code 37, got %d", code)
+		if st.Pid != 42 || st.Status != "running" || st.Exited() {
+			t.Fatalf("state = %s, want a running pid 42", st)
 		}
-		if got := uint64(exitedAt.UnixMicro()); got != exitedAtMicros {
-			t.Fatalf("expected exit timestamp %d, got %d", exitedAtMicros, got)
+	})
+
+	t.Run("an exit systemd reaped is taken from the unit's own record", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(42),
+			"ExecMainCode":   int32(cldExited),
+			"ExecMainStatus": int32(17),
+			"SubState":       "failed",
+			"StatusText":     "",
+		}, &st)
+
+		if st.Pid != 42 || st.ExitCode != 17 || !st.Exited() {
+			t.Fatalf("state = %s, want pid 42 and exit 17", st)
+		}
+	})
+
+	// The create re-exec is the unit's main process when it reaps a workload
+	// systemd never adopted, so ExecMain* describes the re-exec's own exit.
+	t.Run("a reported exit outranks the unit's record of the re-exec", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(7),
+			"ExecMainCode":   int32(cldExited),
+			"ExecMainStatus": int32(3),
+			"SubState":       "failed",
+			"StatusText":     "exited 42",
+			"StatusErrno":    int32(19),
+		}, &st)
+
+		if st.Pid != 42 || st.ExitCode != 19 || !st.Exited() {
+			t.Fatalf("state = %s, want the reported pid 42 and exit 19", st)
+		}
+	})
+
+	t.Run("a reported init failure reports no pid", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(7),
+			"ExecMainCode":   int32(cldExited),
+			"ExecMainStatus": int32(3),
+			"SubState":       "failed",
+			"StatusText":     exitedInit,
+			"StatusErrno":    int32(1),
+		}, &st)
+
+		if st.Pid != 0 || st.ExitCode != 1 || st.Status != exitedInit {
+			t.Fatalf("state = %s, want no pid, exit 1, status %s", st, exitedInit)
+		}
+	})
+
+	t.Run("a reported exit of zero does not inherit the re-exec's exit code", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(7),
+			"ExecMainCode":   int32(cldExited),
+			"ExecMainStatus": int32(3),
+			"SubState":       "failed",
+			"StatusText":     "exited 42",
+			"StatusErrno":    int32(0),
+		}, &st)
+
+		if st.Pid != 42 || st.ExitCode != 0 || !st.Exited() {
+			t.Fatalf("state = %s, want the reported pid 42 and exit 0", st)
+		}
+	})
+
+	t.Run("a signaled exit is reported as 128 plus the signal", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(42),
+			"ExecMainCode":   int32(cldKilled),
+			"ExecMainStatus": int32(9),
+			"SubState":       "failed",
+		}, &st)
+
+		if want := uint32(exitSignalOffset + 9); st.ExitCode != want {
+			t.Fatalf("state = %s, want exit %d", st, want)
+		}
+	})
+
+	// Every unit the reactor tracks emits one of these before it starts, and
+	// reading it as an exit would kill the task before it ever ran.
+	t.Run("a unit that has not started yet reports nothing", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(0),
+			"ExecMainCode":   int32(0),
+			"ExecMainStatus": int32(0),
+			"SubState":       "dead",
+			"Result":         "success",
+			"StatusText":     "",
+			"StatusErrno":    int32(0),
+		}, &st)
+
+		if st.Exited() || st.Status != "" || st.Pid != 0 {
+			t.Fatalf("state = %s, want nothing reported for a unit that never ran", st)
+		}
+	})
+
+	// Identical properties to the case above apart from Result. A unit that fails
+	// before it ever has a main process -- an ExecStartPre that is not allowed to
+	// fail -- must not be discarded as "not started yet", or the task looks alive
+	// with nothing left to report it.
+	t.Run("a unit that failed before it had a main process reports a failure", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID":    uint32(0),
+			"ExecMainCode":   int32(0),
+			"ExecMainStatus": int32(0),
+			"SubState":       "failed",
+			"Result":         "exit-code",
+			"StatusText":     "",
+			"StatusErrno":    int32(0),
+		}, &st)
+
+		if !st.Exited() {
+			t.Fatalf("state = %s, want a terminal state", st)
+		}
+		if st.ExitCode != 255 {
+			t.Fatalf("state = %s, want exit 255", st)
+		}
+		if !st.ExitedAt.After(timeZero) {
+			t.Fatalf("state = %s, want an exit time", st)
+		}
+	})
+
+	// systemd applies the "-" ignore-failure prefix before setting Result, so a
+	// pre-start command that is allowed to fail leaves the unit running.
+	t.Run("a command allowed to fail does not make the unit failed", func(t *testing.T) {
+		var st pState
+		applyUnitProperties(map[string]interface{}{
+			"ExecMainPID": uint32(42),
+			"SubState":    "running",
+			"Result":      "success",
+		}, &st)
+
+		if st.Exited() || st.Pid != 42 {
+			t.Fatalf("state = %s, want a running pid 42", st)
+		}
+	})
+}
+
+func TestParseStatusText(t *testing.T) {
+	t.Run("a status with a pid reports both", func(t *testing.T) {
+		status, pid := parseStatusText("exited 1234")
+		if status != "exited" || pid != 1234 {
+			t.Fatalf("parsed %q/%d, want exited/1234", status, pid)
+		}
+	})
+
+	t.Run("a status without a pid reports no pid", func(t *testing.T) {
+		status, pid := parseStatusText(exitedInit)
+		if status != exitedInit || pid != 0 {
+			t.Fatalf("parsed %q/%d, want %s/0", status, pid, exitedInit)
+		}
+	})
+
+	t.Run("an unreadable pid still reports the exit", func(t *testing.T) {
+		status, pid := parseStatusText("exited not-a-pid")
+		if status != "exited" || pid != 0 {
+			t.Fatalf("parsed %q/%d, want exited/0", status, pid)
+		}
+	})
+
+	t.Run("an empty status text reports nothing", func(t *testing.T) {
+		status, pid := parseStatusText("")
+		if status != "" || pid != 0 {
+			t.Fatalf("parsed %q/%d, want empty", status, pid)
 		}
 	})
 }

--- a/unitevents.go
+++ b/unitevents.go
@@ -84,7 +84,9 @@ func (s *Service) runEventReactor(ctx context.Context) {
 		// that exited during the gap.
 		r.resync()
 
+		s.reactorUp.Store(true)
 		r.consume(runCtx, unitUpdates(runCtx, sigs))
+		s.reactorUp.Store(false)
 
 		cancel()
 		conn.Close()
@@ -218,6 +220,14 @@ func (r *eventReactor) consume(ctx context.Context, updates iter.Seq[unitUpdate]
 func enqueueIfExit(q *unitWorkQueue, units processLookup, u unitUpdate) {
 	switch u.interfaceName {
 	case serviceInterface:
+		if state, ok := helperExitReport(u.changed); ok {
+			p := units.GetByPath(u.pathBase)
+			if p == nil || p.ProcessState().Exited() {
+				return
+			}
+			p.RecordHelperExitState(state)
+			break
+		}
 		state, ok := serviceExitState(u.changed)
 		if !ok {
 			return
@@ -275,20 +285,20 @@ func reconcileWorker(ctx context.Context, q *unitWorkQueue, units processLookup)
 }
 
 // reconcileUnit brings the shim's cached state for a unit up to date with
-// systemd. It is level-driven: rather than acting on a specific event it reads
-// current state, so coalesced or repeated events converge on the same result and
-// SetState emits at most one TaskExit. It returns an error only when the state
-// read itself failed, so the caller can retry; an untracked or already-exited
+// systemd. It is level-driven: rather than acting on a specific event it
+// resolves current state, so coalesced or repeated events converge on the same
+// result and SetState emits at most one TaskExit. It returns an error only when
+// a systemd read failed, so the caller can retry; an untracked or already-exited
 // unit is nothing to do and returns nil.
 //
 // pathBase is the unit's escaped object-path base, resolved through the reactor's
-// index; the systemd read inside LoadState uses the process's own name, so the
-// key is only a lookup handle here.
+// index; the systemd read uses the process's own name, so the key is only a
+// lookup handle here.
 //
-// LoadState reads the persisted exit file first. If it only contains a running
-// state, LoadExitState consumes terminal properties retained from the Service
-// signal. A targeted GetAll on our own unit is the fallback for a Unit exit
-// signal that arrived without a terminal Service update.
+// The reactor's own recording comes first. The signal that enqueued this unit
+// already carried its terminal state, so reading systemd before consulting that
+// spends a property read to compute an answer the shim was handed for free --
+// and then, because the read resolves the exit on its own, never looks at it.
 func reconcileUnit(ctx context.Context, units processLookup, pathBase string) error {
 	p := units.GetByPath(pathBase)
 	if p == nil {
@@ -303,18 +313,23 @@ func reconcileUnit(ctx context.Context, units processLookup, pathBase string) er
 	ctx = log.WithLogger(ctx, log.G(ctx).WithField("unit", p.Name()))
 	ctx = WithShimLog(ctx, p.LogWriter())
 
+	if p.LoadRecordedExitState(ctx) {
+		log.G(ctx).WithField("state", p.ProcessState()).Debug("Reconciled unit from the recorded exit")
+		return nil
+	}
+
+	// Nothing recorded: the exit arrived as a Unit ActiveState transition with
+	// no terminal Service update, or this is the leading pre-start event, or a
+	// reconnect resync is sweeping units whose signals were missed entirely.
+	// Only a read can tell those apart, and the resync case is the one the unit
+	// reference exists to keep recoverable.
 	if err := p.LoadState(ctx); err != nil {
 		return err
 	}
-
-	// Create normally persists only a running state. When it is not terminal for
-	// a started process, consume the Service signal's terminal state or fall back
-	// to the still-loaded unit. A Pid of 0 means the unit never started (the
-	// leading pre-start inactive/dead event), so there is nothing to read.
-	if !p.ProcessState().Exited() && p.Pid() > 0 {
-		if err := p.LoadExitState(ctx); err != nil {
-			return err
-		}
+	// Count a fallback only when the read actually recovered a terminal exit the
+	// reactor missed; a pre-start / non-terminal read is not a reactor miss.
+	if p.ProcessState().Exited() {
+		countState(metricGetAllFallbacks)
 	}
 	log.G(ctx).WithField("state", p.ProcessState()).Debug("Reconciled unit after exit event")
 	return nil

--- a/unitevents_test.go
+++ b/unitevents_test.go
@@ -136,6 +136,57 @@ func TestEnqueueIfExit(t *testing.T) {
 		}
 	})
 
+	t.Run("a reported exit is recorded before reconciliation is enqueued", func(t *testing.T) {
+		p := &fakeProcess{name: unit}
+		q, units := newQueued(p)
+
+		enqueueIfExit(q, units, helperExitUpdate(unit, "exited 42", 19))
+
+		if queueLen(q) != 1 {
+			t.Fatalf("expected the exiting service to be enqueued, queue has %d", queueLen(q))
+		}
+		recorded, ok := p.recordedSystemdExitState()
+		if !ok {
+			t.Fatal("the reported exit was not recorded")
+		}
+		if recorded.Pid != 42 || recorded.ExitCode != 19 {
+			t.Fatalf("recorded state = %s, want pid 42, exit 19", recorded)
+		}
+	})
+
+	// The create re-exec is still the unit's main process when it reports, so
+	// systemd publishes the re-exec's own exit microseconds later. The informer
+	// sees both, and the second must not overwrite the first.
+	t.Run("the re-exec's own exit does not overwrite the exit it reported", func(t *testing.T) {
+		p := &fakeProcess{name: unit}
+		q, units := newQueued(p)
+
+		enqueueIfExit(q, units, helperExitUpdate(unit, "exited 42", 19))
+		enqueueIfExit(q, units, serviceExitUpdate(unit, 7, 3, time.Now().Add(time.Second)))
+
+		recorded, ok := p.recordedSystemdExitState()
+		if !ok {
+			t.Fatal("the reported exit was not recorded")
+		}
+		if recorded.Pid != 42 || recorded.ExitCode != 19 {
+			t.Fatalf("recorded state = %s, want the reported pid 42 and exit 19", recorded)
+		}
+	})
+
+	t.Run("an empty status text is not enqueued as an exit", func(t *testing.T) {
+		p := &fakeProcess{name: unit}
+		q, units := newQueued(p)
+
+		enqueueIfExit(q, units, helperExitUpdate(unit, "", 0))
+
+		if queueLen(q) != 0 {
+			t.Fatalf("expected an empty status text not to enqueue, queue has %d", queueLen(q))
+		}
+		if _, ok := p.recordedSystemdExitState(); ok {
+			t.Fatal("an empty status text was recorded as an exit")
+		}
+	})
+
 	t.Run("a non-exit transition is not enqueued", func(t *testing.T) {
 		q, units := newQueued(&fakeProcess{name: unit})
 		running := newUpdate(unit, changedProps(map[string]string{"ActiveState": "active", "SubState": "running"}))
@@ -209,7 +260,7 @@ func TestReactToUnitEvents(t *testing.T) {
 		}) {
 			t.Fatalf("recorded service exit was not reconciled: %s", p.ProcessState())
 		}
-		if got := p.LoadExitStateCalls(); got != 1 {
+		if got := p.LoadRecordedExitStateCalls(); got != 1 {
 			t.Fatalf("expected one recorded exit-state load, got %d", got)
 		}
 		cancel()
@@ -264,14 +315,10 @@ func TestReactToUnitEvents(t *testing.T) {
 		}
 	})
 
-	t.Run("a started process whose persisted state is not terminal reads the exit code from systemd", func(t *testing.T) {
+	t.Run("an exit the reactor did not record is read from systemd", func(t *testing.T) {
 		p := &fakeProcess{
 			name: unit,
 			loadStateFn: func(f *fakeProcess) error {
-				f.setState(pState{Pid: 42, Status: "running"}) // create's running-state file
-				return nil
-			},
-			loadExitStateFn: func(f *fakeProcess) error {
 				f.setState(pState{Pid: 42, ExitCode: 7, ExitedAt: time.Now()})
 				return nil
 			},
@@ -293,16 +340,49 @@ func TestReactToUnitEvents(t *testing.T) {
 		if got := p.ProcessState().ExitCode; got != 7 {
 			t.Fatalf("expected exit code 7 from systemd, got %d", got)
 		}
-		if got := p.LoadExitStateCalls(); got != 1 {
-			t.Fatalf("expected exactly one systemd exit read, got %d", got)
+		if got := p.LoadRecordedExitStateCalls(); got != 0 {
+			t.Fatalf("expected no recorded exit to consume, got %d", got)
 		}
 		cancel()
 		<-done
 	})
 
-	t.Run("an unstarted process does not read the exit code from systemd", func(t *testing.T) {
+	// The reactor decoded this exit from the signal that enqueued the unit, so a
+	// property read would only recompute what it already has. This is the
+	// regression guard for reading systemd before consulting the recording.
+	t.Run("a recorded exit is applied without reading systemd", func(t *testing.T) {
 		p := &fakeProcess{name: unit, loadStateFn: func(f *fakeProcess) error {
-			return nil // models LoadState no-op for a not-yet-started process (pid==0)
+			t.Error("reconcile read systemd despite holding a recorded exit")
+			return nil
+		}}
+		p.RecordSystemdExitState(pState{Pid: 9, ExitCode: 2, ExitedAt: time.Now()})
+		units := &fakeLookup{m: map[string]Process{unit: p}}
+
+		updates := make(chan unitUpdate, 1)
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		done := make(chan struct{})
+		go func() { reactToUnitEvents(ctx, units, seqFromChan(ctx, updates)); close(done) }()
+
+		updates <- exitUpdate(unit)
+
+		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.ProcessState().Exited() }) {
+			t.Fatal("reactor never applied the recorded exit")
+		}
+		if got := p.ProcessState().ExitCode; got != 2 {
+			t.Fatalf("expected the recorded exit code 2 to stand, got %d", got)
+		}
+		if got := p.LoadStateCalls(); got != 0 {
+			t.Fatalf("expected no systemd read, got %d", got)
+		}
+		cancel()
+		<-done
+	})
+
+	t.Run("a pre-start event does not mark the process exited", func(t *testing.T) {
+		p := &fakeProcess{name: unit, loadStateFn: func(f *fakeProcess) error {
+			return nil // a unit that has not started reports nothing
 		}}
 		units := &fakeLookup{m: map[string]Process{unit: p}}
 
@@ -318,9 +398,6 @@ func TestReactToUnitEvents(t *testing.T) {
 		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.LoadStateCalls() >= 1 }) {
 			t.Fatal("reactor never reconciled the pre-start event")
 		}
-		if got := p.LoadExitStateCalls(); got != 0 {
-			t.Fatalf("expected no systemd exit read for an unstarted unit, got %d", got)
-		}
 		if p.ProcessState().Exited() {
 			t.Fatal("pre-start event spuriously marked the process exited")
 		}
@@ -328,9 +405,9 @@ func TestReactToUnitEvents(t *testing.T) {
 		<-done
 	})
 
-	t.Run("a persisted terminal exit is not re-read from systemd", func(t *testing.T) {
+	t.Run("a read that yields a terminal exit is not followed by another", func(t *testing.T) {
 		p := &fakeProcess{name: unit, loadStateFn: func(f *fakeProcess) error {
-			f.setState(pState{Pid: 9, ExitCode: 2, ExitedAt: time.Now()}) // create's fast-exit file
+			f.setState(pState{Pid: 9, ExitCode: 2, ExitedAt: time.Now()})
 			return nil
 		}}
 		units := &fakeLookup{m: map[string]Process{unit: p}}
@@ -344,14 +421,14 @@ func TestReactToUnitEvents(t *testing.T) {
 
 		updates <- exitUpdate(unit)
 
-		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.LoadStateCalls() >= 1 }) {
+		if !eventually(2*time.Second, time.Millisecond, func() bool { return p.ProcessState().Exited() }) {
 			t.Fatal("reactor never reconciled the unit")
 		}
-		if got := p.LoadExitStateCalls(); got != 0 {
-			t.Fatalf("expected no systemd exit read when the file is already terminal, got %d", got)
+		if got := p.LoadStateCalls(); got != 1 {
+			t.Fatalf("expected exactly one systemd read, got %d", got)
 		}
 		if got := p.ProcessState().ExitCode; got != 2 {
-			t.Fatalf("expected the persisted exit code 2 to stand, got %d", got)
+			t.Fatalf("expected the exit code 2 to stand, got %d", got)
 		}
 		cancel()
 		<-done
@@ -727,6 +804,17 @@ func serviceExitUpdate(unit string, pid, exitCode uint32, exitedAt time.Time) un
 	}
 }
 
+func helperExitUpdate(unit, statusText string, errno int32) unitUpdate {
+	return unitUpdate{
+		pathBase:      systemd.PathBusEscape(unit),
+		interfaceName: serviceInterface,
+		changed: map[string]dbus.Variant{
+			"StatusText":  dbus.MakeVariant(statusText),
+			"StatusErrno": dbus.MakeVariant(errno),
+		},
+	}
+}
+
 // newUpdate builds a unitUpdate the way the decoder does: the reactor keys off
 // the systemd-escaped object-path base, so tests escape the real unit name here
 // rather than hand-writing escaped paths.
@@ -806,15 +894,15 @@ func (l *fakeLookup) remove(name string) {
 }
 
 type fakeProcess struct {
-	name            string
-	mu              sync.Mutex
-	state           pState
-	loadCalls       int32
-	loadExitCalls   int32
-	loadStateFn     func(*fakeProcess) error
-	loadExitStateFn func(*fakeProcess) error
-	systemdExit     pState
-	hasSystemdExit  bool
+	name           string
+	mu             sync.Mutex
+	state          pState
+	loadCalls      int32
+	loadExitCalls  int32
+	loadStateFn    func(*fakeProcess) error
+	systemdExit    pState
+	hasSystemdExit bool
+	helperExit     bool
 }
 
 // LoadState mirrors the real implementations, which do NOT hold the process lock
@@ -833,20 +921,20 @@ func (f *fakeProcess) LoadStateCalls() int {
 	return int(atomic.LoadInt32(&f.loadCalls))
 }
 
-// LoadExitState mirrors the real reconcile-path systemd read. Like LoadState it
-// does not hold the process lock while running loadExitStateFn.
-func (f *fakeProcess) LoadExitState(context.Context) error {
+// LoadRecordedExitState mirrors the real reconcile-path consumption of the
+// reactor's recording: it applies a recorded exit and reports whether there was
+// one, doing no I/O either way.
+func (f *fakeProcess) LoadRecordedExitState(context.Context) bool {
+	state, ok := f.recordedSystemdExitState()
+	if !ok {
+		return false
+	}
 	atomic.AddInt32(&f.loadExitCalls, 1)
-	if f.loadExitStateFn != nil {
-		return f.loadExitStateFn(f)
-	}
-	if state, ok := f.recordedSystemdExitState(); ok {
-		f.setState(state)
-	}
-	return nil
+	f.setState(state)
+	return true
 }
 
-func (f *fakeProcess) LoadExitStateCalls() int {
+func (f *fakeProcess) LoadRecordedExitStateCalls() int {
 	return int(atomic.LoadInt32(&f.loadExitCalls))
 }
 
@@ -858,10 +946,18 @@ func (f *fakeProcess) setState(st pState) {
 
 func (f *fakeProcess) RecordSystemdExitState(state pState) {
 	f.mu.Lock()
-	if !f.hasSystemdExit {
+	if !f.hasSystemdExit && !f.helperExit {
 		f.systemdExit = state
 		f.hasSystemdExit = true
 	}
+	f.mu.Unlock()
+}
+
+func (f *fakeProcess) RecordHelperExitState(state pState) {
+	f.mu.Lock()
+	f.systemdExit = state
+	f.hasSystemdExit = true
+	f.helperExit = true
 	f.mu.Unlock()
 }
 

--- a/unitref_test.go
+++ b/unitref_test.go
@@ -74,22 +74,25 @@ func TestStartTransientUnitAddRefSurvivesGC(t *testing.T) {
 	startClean(pinned, true)
 	startClean(control, false)
 
-	// Confirm both exited cleanly, reading their exit while still loaded.
-	for _, name := range []string{pinned, control} {
-		var st pState
-		if !eventually(10*time.Second, 20*time.Millisecond, func() bool {
-			s, err := loadExitFromUnit(ctx, conn, name)
-			if err == nil && s.Exited() {
-				st = s
-				return true
-			}
-			return false
-		}) {
-			t.Fatalf("%s never reported an exit via systemd", name)
+	// The referenced unit's exit stays readable, which is the whole point of the
+	// reference. The control's does not: a property read on a collected
+	// transient unit re-materializes it as an empty one, which reports no pid
+	// and no exit -- so there is nothing to confirm for it here. That it was
+	// collected at all establishes it exited cleanly, because a failed unit
+	// lingers regardless of the reference.
+	var st pState
+	if !eventually(10*time.Second, 20*time.Millisecond, func() bool {
+		s, err := loadExitFromUnit(ctx, conn, pinned)
+		if err == nil && s.Exited() {
+			st = s
+			return true
 		}
-		if st.ExitCode != 0 {
-			t.Fatalf("%s did not exit cleanly (code %d); a failed unit lingers regardless of the reference", name, st.ExitCode)
-		}
+		return false
+	}) {
+		t.Fatalf("%s never reported an exit via systemd", pinned)
+	}
+	if st.ExitCode != 0 {
+		t.Fatalf("%s did not exit cleanly (code %d)", pinned, st.ExitCode)
 	}
 
 	// The unreferenced control is collected once systemd's GC queue runs (churn

--- a/unitsignals.go
+++ b/unitsignals.go
@@ -117,6 +117,39 @@ func decodeSystemdPropertiesChanged(sig *dbus.Signal) (unitUpdate, bool) {
 	}, true
 }
 
+// helperExitReport extracts the create re-exec's own account of an exit from a
+// Service PropertiesChanged payload. systemd emits the status text it was sent
+// like any other property, so the report reaches the reactor as a signal.
+//
+// This is the only account that exists for a workload the re-exec reaped before
+// systemd could adopt its pid: systemd has no exit record of its own, and the
+// pid rides in the status text because MAINPID= is refused for a process that
+// has already exited. The report carries no timestamp, so the moment it is
+// decoded is the closest thing to one -- the exit it describes has only just
+// happened.
+func helperExitReport(changed map[string]dbus.Variant) (pState, bool) {
+	v, ok := changed["StatusText"]
+	if !ok {
+		return pState{}, false
+	}
+	text, ok := v.Value().(string)
+	if !ok {
+		return pState{}, false
+	}
+	status, pid := parseStatusText(text)
+	if status != exitedInit && status != "exited" {
+		return pState{}, false
+	}
+
+	st := pState{Pid: pid, Status: status, ExitedAt: time.Now()}
+	if e, ok := changed["StatusErrno"]; ok {
+		if errno, ok := e.Value().(int32); ok && errno > 0 {
+			st.ExitCode = uint32(errno)
+		}
+	}
+	return st, true
+}
+
 func serviceExitState(changed map[string]dbus.Variant) (pState, bool) {
 	pidValue, ok := changed["ExecMainPID"]
 	if !ok {

--- a/unitsignals_test.go
+++ b/unitsignals_test.go
@@ -157,6 +157,91 @@ func TestServiceExitState(t *testing.T) {
 	})
 }
 
+func TestHelperExitReport(t *testing.T) {
+	t.Run("a reported exit carries the workload's pid and exit code", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"StatusText":  dbus.MakeVariant("exited 1234"),
+			"StatusErrno": dbus.MakeVariant(int32(19)),
+		}
+
+		state, ok := helperExitReport(changed)
+		if !ok {
+			t.Fatal("a reported exit was not recognized")
+		}
+		if state.Pid != 1234 || state.ExitCode != 19 || state.Status != "exited" {
+			t.Fatalf("state = %s, want pid 1234, exit 19, status exited", state)
+		}
+		if !state.Exited() {
+			t.Fatalf("state = %s, want it to be terminal", state)
+		}
+	})
+
+	// runc failing is not the workload exiting, and the pid runc ran under must
+	// never be reported as the workload's.
+	t.Run("a reported init failure carries runc's exit code and no pid", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"StatusText":  dbus.MakeVariant(exitedInit),
+			"StatusErrno": dbus.MakeVariant(int32(1)),
+		}
+
+		state, ok := helperExitReport(changed)
+		if !ok {
+			t.Fatal("a reported init failure was not recognized")
+		}
+		if state.Pid != 0 || state.ExitCode != 1 || state.Status != exitedInit {
+			t.Fatalf("state = %s, want no pid, exit 1, status %s", state, exitedInit)
+		}
+	})
+
+	t.Run("a workload that exited zero is still terminal", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"StatusText":  dbus.MakeVariant("exited 1234"),
+			"StatusErrno": dbus.MakeVariant(int32(0)),
+		}
+
+		state, ok := helperExitReport(changed)
+		if !ok {
+			t.Fatal("a reported zero exit was not recognized")
+		}
+		if state.ExitCode != 0 || !state.Exited() {
+			t.Fatalf("state = %s, want exit 0 and terminal", state)
+		}
+	})
+
+	// systemd emits StatusText on every Service property change, so the empty
+	// value has to stay silent or every running unit would look like an exit.
+	t.Run("an empty status text is not an exit", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"StatusText":  dbus.MakeVariant(""),
+			"StatusErrno": dbus.MakeVariant(int32(0)),
+		}
+
+		if _, ok := helperExitReport(changed); ok {
+			t.Fatal("an empty status text was recognized as an exit")
+		}
+	})
+
+	t.Run("a status text the shim did not write is not an exit", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"StatusText": dbus.MakeVariant("Ready to serve requests"),
+		}
+
+		if _, ok := helperExitReport(changed); ok {
+			t.Fatal("an unrelated status text was recognized as an exit")
+		}
+	})
+
+	t.Run("service properties without a status text are left to the systemd record", func(t *testing.T) {
+		changed := map[string]dbus.Variant{
+			"ExecMainPID": dbus.MakeVariant(uint32(42)),
+		}
+
+		if _, ok := helperExitReport(changed); ok {
+			t.Fatal("an exit was reported without a status text")
+		}
+	})
+}
+
 func TestUnitUpdates(t *testing.T) {
 	changed := changedProps(map[string]string{"ActiveState": "failed"})
 

--- a/wait.go
+++ b/wait.go
@@ -61,12 +61,14 @@ func (s *Service) Wait(ctx context.Context, r *taskapi.WaitRequest) (retResp *ta
 		}
 	}
 
-	if err := p.LoadState(ctx); err != nil {
-		log.G(ctx).WithError(err).Warning("Error loading process state")
-	}
-	if !p.ProcessState().Exited() && p.Pid() > 0 {
-		if err := p.LoadExitState(ctx); err != nil {
-			log.G(ctx).WithError(err).Warning("Error loading process exit state")
+	// A read here is only worth making when the shim has reason to doubt its own
+	// state. While the signal stream is up it does not: no unit event can have
+	// been missed, so an exit that has happened is already applied (and
+	// waitForExit returns without parking) or will arrive and wake the waiter.
+	// With the stream down, nothing will deliver it, so look once on the way in.
+	if !p.ProcessState().Exited() && !s.reactorUp.Load() && !p.LoadRecordedExitState(ctx) {
+		if err := p.LoadState(ctx); err != nil {
+			log.G(ctx).WithError(err).Warning("Error loading process state")
 		}
 	}
 
@@ -76,10 +78,12 @@ func (s *Service) Wait(ctx context.Context, r *taskapi.WaitRequest) (retResp *ta
 	}
 	log.G(ctx).Debugf("%+v", st)
 
-	if !st.ExitedAt.After(timeZero) {
-		getUnitState(ctx, s.conn, p.Name(), &st)
-	}
-
+	// Every terminal state carries an exit time by construction:
+	// applyUnitProperties stamps one for any state it reports as exited, and the
+	// synthetic exits the shim records set it explicitly. So there is nothing to
+	// repair here -- if this fires, an exit reached the process by a path that
+	// skipped that, which is a bug rather than something to paper over with a
+	// read.
 	if !st.ExitedAt.After(timeZero) {
 		log.G(ctx).Error("No exit time set")
 	}

--- a/wait_test.go
+++ b/wait_test.go
@@ -17,9 +17,9 @@ func TestServiceWaitReconcilesExitState(t *testing.T) {
 		id        = "container"
 	)
 
-	t.Run("nonterminal disk state falls back to systemd before waiting", func(t *testing.T) {
+	t.Run("a process with no recorded exit is read from systemd before waiting", func(t *testing.T) {
 		p := newWaitProcess(id, pState{Pid: 42, Status: "running"})
-		p.loadExitStateFn = func(p *fakeProcess) error {
+		p.loadStateFn = func(p *fakeProcess) error {
 			p.setState(pState{
 				Pid:      42,
 				ExitCode: 9,
@@ -40,22 +40,25 @@ func TestServiceWaitReconcilesExitState(t *testing.T) {
 		if response.ExitStatus != 9 {
 			t.Fatalf("exit status = %d, want 9", response.ExitStatus)
 		}
-		if got := p.LoadExitStateCalls(); got != 1 {
-			t.Fatalf("systemd exit-state loads = %d, want 1", got)
+		if got := p.LoadStateCalls(); got != 1 {
+			t.Fatalf("systemd reads = %d, want 1", got)
 		}
 	})
 
-	t.Run("terminal disk state does not fall back to systemd", func(t *testing.T) {
+	// The reactor already decoded this exit, so Wait must not spend a property
+	// read recomputing it.
+	t.Run("a recorded exit answers the wait without reading systemd", func(t *testing.T) {
 		p := newWaitProcess(id, pState{Pid: 42, Status: "running"})
 		p.loadStateFn = func(p *fakeProcess) error {
-			p.setState(pState{
-				Pid:      42,
-				ExitCode: 7,
-				ExitedAt: time.Now(),
-				Status:   "failed",
-			})
+			t.Error("wait read systemd despite a recorded exit")
 			return nil
 		}
+		p.RecordSystemdExitState(pState{
+			Pid:      42,
+			ExitCode: 7,
+			ExitedAt: time.Now(),
+			Status:   "failed",
+		})
 		service := newWaitService(t, namespace, id, p)
 
 		response, err := service.Wait(
@@ -68,8 +71,8 @@ func TestServiceWaitReconcilesExitState(t *testing.T) {
 		if response.ExitStatus != 7 {
 			t.Fatalf("exit status = %d, want 7", response.ExitStatus)
 		}
-		if got := p.LoadExitStateCalls(); got != 0 {
-			t.Fatalf("systemd exit-state loads = %d, want 0", got)
+		if got := p.LoadStateCalls(); got != 0 {
+			t.Fatalf("systemd reads = %d, want 0", got)
 		}
 	})
 }


### PR DESCRIPTION
The create re-exec reported the workload twice: over `sd_notify`, and as a JSON file (`EXIT_STATE_PATH`) that the shim read back. Only the file was ever read — init units were `Type=forking`, which implies `NotifyAccess=none`, so systemd discarded every notification the re-exec sent.

This removes the file and makes the notify path real.

### Fixes #28, and one thing that issue got wrong

`Type=notify` alone is not enough. It implies `NotifyAccess=main`, and once `MAINPID=` is accepted the workload *is* the main process — so the re-exec's report of a workload that died during the handoff is refused, and systemd has no record of its own either, because the re-exec reaped it. That exit is lost outright. Verified against systemd 260:

```
NotifyAccess=main   ->  StatusText=""              StatusErrno=0    <- refused
NotifyAccess=all    ->  StatusText="exited 539391" StatusErrno=19   <- lands
```

`sd_notify_enable` is gone. It only toggled the unit type, and never gave the workload the `NOTIFY_SOCKET` its name implied. Proto field is `reserved`.

It also fixes a bug the switch would otherwise introduce: the `PrivateMounts` path never sets a status, so `notifyWorkload` matched nothing and the re-exec exited without `READY=1`. Harmless under `forking`; under `notify` every such container fails to start.

### The channel

Exits arrive as `STATUS=`/`ERRNO=`, which systemd exposes both on a property read and in the signal stream, so one decoder (`applyUnitProperties`) serves both. The pid rides in the `STATUS` text for the one case `MAINPID=` cannot cover — systemd refuses a pid that has already exited.

Two accounts of the same unit then need ordering, and both cost a regression if got wrong:

- The re-exec is still the main process when it reports, so systemd publishes *its* exit microseconds later. A recorded report now outranks anything systemd publishes afterwards.
- `ExecMainPID` is the re-exec's pid until the handoff completes, and `CopyTo` latches the first pid permanently — so it is ignored while the unit is still activating.

### Fewer D-Bus reads

Removing the file turned four on-disk reads per container into four property reads. Those are gone again: the pid comes from runc's pid file, an immediate exit is what the start job's result already says, and `Wait` trusts the event stream while it is connected. Reads per 20 containers, measured with `nix run .#benchvm`:

| | baseline | file removed | now |
|---|---|---|---|
| container p=1/4/8 | 20 / 20 / 19 | 120 / 116 / 113 | 20 / 20 / 20 |
| scale n=1/5/10/25 | 1 / 5 / 10 / 25 | 5 / 25 / 50 / 125 | 1 / 5 / 10 / 25 |
| exec p=1 | 0 | 80 | 20 |

Exec's baseline is 0 only because `execProcess.LoadState` read the file and never systemd. The one read per unit that remains is the pre-start reconcile.

### An unrelated bug this surfaced

A unit that fails before it ever has a main process — an `ExecStartPre` that is not allowed to fail — reads identically to one that has not started yet: `ExecMainPID=0`, `SubState` stopped, no status text. `Result` tells them apart, and systemd sets it *after* applying the `-` ignore-failure prefix, so a command allowed to fail never shows up. Without this, a container whose rootfs mount failed reported a successful create with pid 0.

### Testing

`go test -race ./...` green as root. New coverage for the decode precedence, the record authority, the notify unit properties, `Wait`'s missed-exit recovery, and the rootfs mount failure; several existing tests rewritten because they asserted on the old two-source model. The mount-failure test needs no privileges — a mount that must fail fails unprivileged too.

Two limits worth naming: the `PrivateMounts` and rootfs-success paths still need `CAP_SYS_ADMIN`, so they are exercised only by the root CI job; and the benchmark numbers above predate the `Result` fix, which should not move them but has not been re-measured.